### PR TITLE
feat(grant): add interactive append mode

### DIFF
--- a/cmd/grant.go
+++ b/cmd/grant.go
@@ -445,6 +445,10 @@ This can be overridden with the --destination-outside-root flag.`,
 		absConfigFile = filepath.Join(cfg.Root, filepath.Base(configFile))
 
 		interactive, _ := cmd.Flags().GetBool("interactive")
+		appendMode, _ := cmd.Flags().GetBool("append")
+		if appendMode && !interactive {
+			return fmt.Errorf("--append requires --interactive")
+		}
 
 		// Check if stdout is a terminal
 		stat, _ := os.Stdout.Stat()
@@ -509,6 +513,7 @@ This can be overridden with the --destination-outside-root flag.`,
 			Command:    "grant",
 			Leases:     leases,
 			Override:   override,
+			Append:     false,
 			ConfigFile: absConfigFile,
 		}
 		// If in test mode, don't try to send to the daemon.
@@ -642,6 +647,7 @@ func init() {
 	grantCmd.Flags().StringP("config", "c", "env-lease.toml", "Path to config file.")
 	grantCmd.Flags().String("local-config", "", "Path to local override config file.")
 	grantCmd.Flags().BoolP("interactive", "i", false, "Prompt for confirmation before granting each lease.")
+	grantCmd.Flags().Bool("append", false, "In interactive mode, keep existing granted leases and only add newly approved leases. Skipped prompts are left unchanged.")
 	grantCmd.Flags().Bool("destination-outside-root", false, "Allow file-based leases to write outside of the project root.")
 	rootCmd.AddCommand(grantCmd)
 }
@@ -735,7 +741,12 @@ func interactiveGrant(cmd *cobra.Command, cfg *config.Config, absConfigFile stri
 
 	continueOnError, _ := cmd.Flags().GetBool("continue-on-error")
 	override, _ := cmd.Flags().GetBool("override")
+	appendMode, _ := cmd.Flags().GetBool("append")
 	noDirenv, _ := cmd.Flags().GetBool("no-direnv")
+
+	if appendMode {
+		fmt.Fprintln(os.Stderr, "Append mode enabled: skipped leases will remain unchanged.")
+	}
 
 	var errs []grantError
 
@@ -891,7 +902,7 @@ func interactiveGrant(cmd *cobra.Command, cfg *config.Config, absConfigFile stri
 
 	// ------- Phase 4: GRANT (single request) -------
 	slog.Debug("interactive grant: phase 4 start", "final_lease_count", len(finalLeases))
-	req := ipc.GrantRequest{Command: "grant", Leases: finalLeases, Override: override, ConfigFile: absConfigFile}
+	req := ipc.GrantRequest{Command: "grant", Leases: finalLeases, Override: override, Append: appendMode, ConfigFile: absConfigFile}
 	if client != nil {
 		var resp ipc.GrantResponse
 		if err := client.Send(req, &resp); err != nil {

--- a/cmd/grant_interactive_test.go
+++ b/cmd/grant_interactive_test.go
@@ -13,6 +13,7 @@ func TestGrantRunE_Interactive(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 	os.Setenv("ENV_LEASE_TEST", "1")
+	grantCmd.Flags().Set("append", "false")
 
 	// Helper to create a dummy config file
 	writeConfig := func(content string) string {

--- a/cmd/grant_test.go
+++ b/cmd/grant_test.go
@@ -11,6 +11,8 @@ import (
 func TestGrantRunE(t *testing.T) {
 	tempDir := t.TempDir()
 	os.Setenv("ENV_LEASE_TEST", "1")
+	grantCmd.Flags().Set("interactive", "false")
+	grantCmd.Flags().Set("append", "false")
 
 	// Helper to create a dummy config file
 	writeConfig := func(content string) string {
@@ -233,6 +235,30 @@ format = "%s=%q"
 			t.Fatalf("expected content %q, got %q", expectedContent, string(content))
 		}
 	})
+
+	t.Run("append requires interactive", func(t *testing.T) {
+		destFile := filepath.Join(tempDir, ".env.append")
+		configContent := `
+[[lease]]
+source = "mock"
+destination = "` + destFile + `"
+variable = "APPEND_KEY"
+duration = "1m"
+`
+		configFile := writeConfig(configContent)
+		grantCmd.Flags().Set("config", configFile)
+		grantCmd.Flags().Set("interactive", "false")
+		grantCmd.Flags().Set("append", "true")
+		defer grantCmd.Flags().Set("append", "false")
+
+		err := grantCmd.RunE(grantCmd, []string{})
+		if err == nil {
+			t.Fatal("expected an error when --append is used without --interactive")
+		}
+		if !strings.Contains(err.Error(), "--append requires --interactive") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestGrantPreflightDaemonNotRunning(t *testing.T) {
@@ -259,6 +285,7 @@ duration = "1m"
 		grantCmd.Flags().Set("interactive", "false")
 		grantCmd.Flags().Set("continue-on-error", "false")
 		grantCmd.Flags().Set("override", "false")
+		grantCmd.Flags().Set("append", "false")
 		grantCmd.Flags().Set("no-direnv", "false")
 
 		_ = grantCmd.RunE(grantCmd, []string{})
@@ -266,10 +293,14 @@ duration = "1m"
 		return
 	}
 
+	xdgRuntime := t.TempDir()
+	xdgState := t.TempDir()
 	cmd := exec.Command(os.Args[0], "-test.run", "TestGrantPreflightDaemonNotRunning")
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_HELPER_PROCESS=1",
 		"ENV_LEASE_TEST=",
+		"XDG_RUNTIME_DIR="+xdgRuntime,
+		"XDG_STATE_HOME="+xdgState,
 	)
 
 	output, err := cmd.CombinedOutput()

--- a/cmd/revoke_test.go
+++ b/cmd/revoke_test.go
@@ -35,10 +35,14 @@ duration = "1m"
 		return
 	}
 
+	xdgRuntime := t.TempDir()
+	xdgState := t.TempDir()
 	cmd := exec.Command(os.Args[0], "-test.run", "TestRevokePreflightDaemonNotRunning")
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_HELPER_PROCESS_REVOKE=1",
 		"ENV_LEASE_TEST=",
+		"XDG_RUNTIME_DIR="+xdgRuntime,
+		"XDG_STATE_HOME="+xdgState,
 	)
 
 	output, err := cmd.CombinedOutput()

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -325,6 +325,7 @@ env-lease idle uninstall
 - `--local-config`: Path to the local override configuration file. This takes precedence over the environment variables.
 - `--continue-on-error`: Continue granting leases even if one fails.
 - `-i`, `--interactive`: Prompt for confirmation before granting each lease.
+- `--append`: Interactive-only additive mode. Keeps existing granted leases and only adds newly approved leases; skipped prompts remain unchanged.
 - `--destination-outside-root`: Allow file-based leases to write outside of the project root.
 
 #### `revoke`
@@ -341,6 +342,8 @@ The `-i` or `--interactive` flag can be used with `grant` and `revoke` to confir
 - `a`: Yes to this and all subsequent actions in this run.
 - `d`: No to this and all subsequent actions in this run.
 - `?`: Show help.
+
+In `env-lease grant -i --append`, `n`/`<Enter>` means **skip and leave existing lease state unchanged** (no revoke/no grant).
 
 **Granting Leases:**
 

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -57,24 +57,28 @@ func (d *Daemon) handleGrant(payload []byte) ([]byte, error) {
 	}
 	slog.Debug("Received grant request", "leases", len(req.Leases))
 
-	// Revoke any leases that are in the state but not in the request
-	activeLeases := d.state.LeasesForConfigFile(req.ConfigFile)
-	for key, activeLease := range activeLeases {
-		found := false
-		for _, reqLease := range req.Leases {
-			if activeLease.Source == reqLease.Source && activeLease.Destination == reqLease.Destination && activeLease.Variable == reqLease.Variable {
-				found = true
-				break
+	if !req.Append {
+		// Revoke any leases that are in the state but not in the request.
+		activeLeases := d.state.LeasesForConfigFile(req.ConfigFile)
+		for key, activeLease := range activeLeases {
+			found := false
+			for _, reqLease := range req.Leases {
+				if activeLease.Source == reqLease.Source && activeLease.Destination == reqLease.Destination && activeLease.Variable == reqLease.Variable {
+					found = true
+					break
+				}
+			}
+			if !found {
+				slog.Info("Revoking lease removed from config", "key", key)
+				if err := d.revoker.Revoke(activeLease); err != nil {
+					slog.Error("Failed to revoke lease removed from config", "key", key, "err", err)
+					// Continue trying to revoke other leases
+				}
+				delete(d.state.Leases, key)
 			}
 		}
-		if !found {
-			slog.Info("Revoking lease removed from config", "key", key)
-			if err := d.revoker.Revoke(activeLease); err != nil {
-				slog.Error("Failed to revoke lease removed from config", "key", key, "err", err)
-				// Continue trying to revoke other leases
-			}
-			delete(d.state.Leases, key)
-		}
+	} else {
+		slog.Debug("Grant request in append mode; skipping reconciliation revokes", "config_file", req.ConfigFile)
 	}
 
 	for _, l := range req.Leases {

--- a/internal/daemon/handlers_test.go
+++ b/internal/daemon/handlers_test.go
@@ -105,3 +105,63 @@ func TestHandleGrant_RevokesRemovedLeases(t *testing.T) {
 		t.Fatalf("expected revoked lease to be MY_VAR_2, got %s", revoker.revoked[0].Variable)
 	}
 }
+
+func TestHandleGrant_AppendDoesNotRevokeRemovedLeases(t *testing.T) {
+	state := NewState()
+	clock := &mockClock{now: time.Now()}
+	revoker := &mockRevoker{}
+	notifier := &mockNotifier{}
+	daemon := NewDaemon(state, "/dev/null", clock, nil, revoker, notifier)
+
+	lease1 := ipc.Lease{
+		Source:      "1password",
+		Destination: "/tmp/foo",
+		LeaseType:   "env",
+		Variable:    "MY_VAR_1",
+		Duration:    "1h",
+	}
+	lease2 := ipc.Lease{
+		Source:      "1password",
+		Destination: "/tmp/foo",
+		LeaseType:   "env",
+		Variable:    "MY_VAR_2",
+		Duration:    "1h",
+	}
+
+	// First grant both leases.
+	req := ipc.GrantRequest{
+		Command:    "grant",
+		Leases:     []ipc.Lease{lease1, lease2},
+		ConfigFile: "/tmp/env-lease.toml",
+	}
+	payload, _ := json.Marshal(req)
+	_, err := daemon.handleGrant(payload)
+	if err != nil {
+		t.Fatalf("initial handleGrant failed: %v", err)
+	}
+
+	// Then submit only lease1 in append mode. lease2 should remain active.
+	req = ipc.GrantRequest{
+		Command:    "grant",
+		Leases:     []ipc.Lease{lease1},
+		Append:     true,
+		ConfigFile: "/tmp/env-lease.toml",
+	}
+	payload, _ = json.Marshal(req)
+	_, err = daemon.handleGrant(payload)
+	if err != nil {
+		t.Fatalf("append handleGrant failed: %v", err)
+	}
+
+	key1 := "1password;/tmp/foo;MY_VAR_1"
+	key2 := "1password;/tmp/foo;MY_VAR_2"
+	if _, ok := daemon.state.Leases[key1]; !ok {
+		t.Fatal("lease 1 not found in state")
+	}
+	if _, ok := daemon.state.Leases[key2]; !ok {
+		t.Fatal("lease 2 should remain in state during append")
+	}
+	if len(revoker.revoked) != 0 {
+		t.Fatalf("expected no revoked leases in append mode, got %d", len(revoker.revoked))
+	}
+}

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -20,6 +20,7 @@ type GrantRequest struct {
 	Command    string
 	Leases     []Lease
 	Override   bool
+	Append     bool
 	ConfigFile string
 }
 


### PR DESCRIPTION
## Summary
- add `--append` flag to `env-lease grant` for interactive additive grants
- enforce `--append` can only be used with `--interactive`
- add `Append` to IPC grant request and update daemon grant handling to skip reconciliation revokes in append mode
- document append behavior in `docs/USAGE.md`
- add/adjust tests for append behavior and daemon-preflight isolation

## Behavior
With `env-lease grant -i --append`, answering `n` now means skip/no-op (leave current lease state unchanged), allowing subsequent runs to add new approvals without revoking previously granted leases.

## Testing
- `go test ./...`
- `just test`
