### PR TITLE
fix(daemon): persist retry queue updates

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -373,6 +373,7 @@ func (d *Daemon) processRetryQueue() {
 	defer d.mu.Unlock()
 
 	now := d.clock.Now()
+	stateChanged := false
 	for i := len(d.state.RetryQueue) - 1; i >= 0; i-- {
 		item := d.state.RetryQueue[i]
 		if now.After(item.NextRetryTime) {
@@ -385,6 +386,7 @@ func (d *Daemon) processRetryQueue() {
 				item.Attempts++
 				item.NextRetryTime = now.Add(time.Duration(item.Attempts*2) * time.Second) // Exponential backoff
 				d.state.RetryQueue[i] = item
+				stateChanged = true
 
 				// Create failure file if necessary
 				if now.Sub(item.InitialFailure) > 5*time.Minute {
@@ -395,7 +397,14 @@ func (d *Daemon) processRetryQueue() {
 			} else {
 				// Success, remove from queue
 				d.state.RetryQueue = append(d.state.RetryQueue[:i], d.state.RetryQueue[i+1:]...)
+				stateChanged = true
 			}
+		}
+	}
+
+	if stateChanged {
+		if err := d.state.SaveState(d.statePath); err != nil {
+			slog.Error("Failed to save state after processing retry queue", "err", err)
 		}
 	}
 	slog.Debug("Finished processing retry queue.")

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -217,3 +217,72 @@ func TestDaemon_ShutdownRevokesLeasesAndClearsState(t *testing.T) {
 	assert.Contains(t, string(envContent), "ENV_VAR=")
 	assert.NotContains(t, string(envContent), "value", "env variable should be cleared during shutdown")
 }
+
+func TestDaemon_processRetryQueue_PersistsBackoffUpdate(t *testing.T) {
+	tempDir := t.TempDir()
+	statePath := filepath.Join(tempDir, "state.json")
+	now := time.Now()
+
+	state := NewState()
+	state.RetryQueue = []RetryItem{
+		{
+			Lease: &config.Lease{
+				Source:      "onepassword://vault/item/retry",
+				Destination: filepath.Join(tempDir, "retry.env"),
+				LeaseType:   "env",
+			},
+			Attempts:       1,
+			NextRetryTime:  now.Add(-1 * time.Second),
+			InitialFailure: now.Add(-1 * time.Minute),
+		},
+	}
+	require.NoError(t, state.SaveState(statePath))
+
+	revoker := &mockRevoker{RevokeFunc: func(lease *config.Lease) error {
+		return fmt.Errorf("revoke failed")
+	}}
+	d := NewDaemon(state, statePath, &mockClock{now: now}, nil, revoker, nil)
+
+	d.processRetryQueue()
+
+	require.Len(t, state.RetryQueue, 1)
+	assert.Equal(t, 2, state.RetryQueue[0].Attempts)
+	assert.WithinDuration(t, now.Add(4*time.Second), state.RetryQueue[0].NextRetryTime, time.Millisecond)
+
+	reloaded, err := LoadState(statePath)
+	require.NoError(t, err)
+	require.Len(t, reloaded.RetryQueue, 1)
+	assert.Equal(t, 2, reloaded.RetryQueue[0].Attempts)
+	assert.WithinDuration(t, now.Add(4*time.Second), reloaded.RetryQueue[0].NextRetryTime, time.Millisecond)
+}
+
+func TestDaemon_processRetryQueue_PersistsSuccessfulRemoval(t *testing.T) {
+	tempDir := t.TempDir()
+	statePath := filepath.Join(tempDir, "state.json")
+	now := time.Now()
+
+	state := NewState()
+	state.RetryQueue = []RetryItem{
+		{
+			Lease: &config.Lease{
+				Source:      "onepassword://vault/item/retry-success",
+				Destination: filepath.Join(tempDir, "retry-success.env"),
+				LeaseType:   "env",
+			},
+			Attempts:       1,
+			NextRetryTime:  now.Add(-1 * time.Second),
+			InitialFailure: now.Add(-1 * time.Minute),
+		},
+	}
+	require.NoError(t, state.SaveState(statePath))
+
+	d := NewDaemon(state, statePath, &mockClock{now: now}, nil, &mockRevoker{}, nil)
+
+	d.processRetryQueue()
+
+	assert.Empty(t, state.RetryQueue)
+
+	reloaded, err := LoadState(statePath)
+	require.NoError(t, err)
+	assert.Empty(t, reloaded.RetryQueue)
+}


### PR DESCRIPTION
## Summary
- persist daemon retry queue mutations in `processRetryQueue` when items are removed or backoff metadata is updated
- log state save failures after retry queue processing
- add daemon tests to verify retry queue changes are persisted to the state file

## Tests
- go test ./internal/daemon
- go test ./...