### PR TITLE
fix: match orphaned leases by source+destination+variable

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -149,17 +149,17 @@ func (d *Daemon) revokeOrphanedLeases() {
 			continue
 		}
 
-		// Create a map of leases defined in the config for efficient lookup
-		configLeases := make(map[string]struct{})
+		// Create a map of leases defined in the config for efficient lookup.
+		// Lease identity must include source + destination + variable to avoid
+		// collisions when multiple leases share a source.
+		configLeases := make(map[string]struct{}, len(cfg.Lease))
 		for _, l := range cfg.Lease {
-			// The key in the state is a composite of source, destination, and variable.
-			// We only need to check the source for existence.
-			configLeases[l.Source] = struct{}{}
+			configLeases[leaseIdentity(l.Source, l.Destination, l.Variable)] = struct{}{}
 		}
 
 		// Check active leases against the config
 		for key, activeLease := range d.state.LeasesForConfigFile(configFile) {
-			if _, exists := configLeases[activeLease.Source]; !exists {
+			if _, exists := configLeases[leaseIdentity(activeLease.Source, activeLease.Destination, activeLease.Variable)]; !exists {
 				slog.Info("Lease removed from config, revoking", "key", key)
 				if activeLease.LeaseType == "shell" {
 					slog.Debug("Ignoring shell lease type in orphaned lease check", "key", key)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -153,27 +153,48 @@ func (d *Daemon) revokeOrphanedLeases() {
 		// Lease identity must include source + destination + variable to avoid
 		// collisions when multiple leases share a source.
 		configLeases := make(map[string]struct{}, len(cfg.Lease))
+		explodeParents := make(map[string]struct{})
 		for _, l := range cfg.Lease {
-			configLeases[leaseIdentity(l.Source, l.Destination, l.Variable)] = struct{}{}
+			destination, err := canonicalLeaseDestination(cfg.Root, l)
+			if err != nil {
+				slog.Warn("Could not normalize lease destination; skipping config lease", "source", l.Source, "destination", l.Destination, "err", err)
+				continue
+			}
+
+			configLeases[leaseIdentity(l.Source, destination, l.Variable)] = struct{}{}
+			if hasExplodeTransform(l.Transform) {
+				// Explode leases create a parent entry with an empty variable and
+				// child entries that reference ParentSource at runtime.
+				configLeases[leaseIdentity(l.Source, destination, "")] = struct{}{}
+				explodeParents[parentLeaseIdentity(l.Source, destination)] = struct{}{}
+			}
 		}
 
 		// Check active leases against the config
 		for key, activeLease := range d.state.LeasesForConfigFile(configFile) {
-			if _, exists := configLeases[leaseIdentity(activeLease.Source, activeLease.Destination, activeLease.Variable)]; !exists {
-				slog.Info("Lease removed from config, revoking", "key", key)
-				if activeLease.LeaseType == "shell" {
-					slog.Debug("Ignoring shell lease type in orphaned lease check", "key", key)
-					delete(d.state.Leases, key)
-					stateChanged = true
+			activeIdentity := leaseIdentity(activeLease.Source, activeLease.Destination, activeLease.Variable)
+			if _, exists := configLeases[activeIdentity]; exists {
+				continue
+			}
+			if activeLease.ParentSource != "" {
+				if _, exists := explodeParents[activeLease.ParentSource]; exists {
 					continue
 				}
-				if err := d.revoker.Revoke(activeLease); err != nil {
-					slog.Error("Failed to revoke orphaned lease", "key", key, "err", err)
-					// Optionally, add to a retry queue here as well
-				} else {
-					delete(d.state.Leases, key)
-					stateChanged = true
-				}
+			}
+
+			slog.Info("Lease removed from config, revoking", "key", key)
+			if activeLease.LeaseType == "shell" {
+				slog.Debug("Ignoring shell lease type in orphaned lease check", "key", key)
+				delete(d.state.Leases, key)
+				stateChanged = true
+				continue
+			}
+			if err := d.revoker.Revoke(activeLease); err != nil {
+				slog.Error("Failed to revoke orphaned lease", "key", key, "err", err)
+				// Optionally, add to a retry queue here as well
+			} else {
+				delete(d.state.Leases, key)
+				stateChanged = true
 			}
 		}
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -125,16 +125,25 @@ variable = "VAR2"
 
 	// Add leases to the state, pretending they were granted from the config
 	state.Leases["lease1"] = &config.Lease{
-		Source:     "onepassword://vault/item/field1",
-		ConfigFile: configFile.Name(),
+		Source:      "onepassword://vault/item/field1",
+		Destination: "/tmp/file1",
+		Variable:    "VAR1",
+		LeaseType:   "env",
+		ConfigFile:  configFile.Name(),
 	}
 	state.Leases["lease2"] = &config.Lease{
-		Source:     "onepassword://vault/item/field2", // This one will be removed from config
-		ConfigFile: configFile.Name(),
+		Source:      "onepassword://vault/item/field2", // This one will be removed from config
+		Destination: "/tmp/file2",
+		Variable:    "VAR2",
+		LeaseType:   "env",
+		ConfigFile:  configFile.Name(),
 	}
 	state.Leases["lease3"] = &config.Lease{
-		Source:     "onepassword://vault/item/field3", // This one will be removed from config
-		ConfigFile: configFile.Name(),
+		Source:      "onepassword://vault/item/field3", // This one will be removed from config
+		Destination: "/tmp/file3",
+		Variable:    "VAR3",
+		LeaseType:   "env",
+		ConfigFile:  configFile.Name(),
 	}
 
 	// Act: Modify the config file to "remove" lease2 and lease3
@@ -155,6 +164,80 @@ variable = "VAR1"
 	assert.Equal(t, 2, revoker.RevokeCount, "Revoke should be called for the two removed leases")
 	assert.Len(t, state.Leases, 1, "Only one lease should remain in the state")
 	assert.NotNil(t, state.Leases["lease1"], "Lease1 should still be in the state")
+}
+
+func TestDaemon_revokeOrphanedLeases_RevokesRemovedSiblingWithSameSource(t *testing.T) {
+	state := NewState()
+	clock := &mockClock{now: time.Now()}
+	revoker := &mockRevoker{}
+	notifier := &mockNotifier{}
+
+	stateFile, err := os.CreateTemp("", "env-lease-state-*.json")
+	require.NoError(t, err)
+	defer os.Remove(stateFile.Name())
+
+	daemon := NewDaemon(state, stateFile.Name(), clock, nil, revoker, notifier)
+
+	configFile, err := os.CreateTemp("", "env-lease-*.toml")
+	require.NoError(t, err)
+	defer os.Remove(configFile.Name())
+
+	tempDir := t.TempDir()
+	sharedSource := "onepassword://vault/item/shared"
+	destinationA := filepath.Join(tempDir, "a.env")
+	destinationB := filepath.Join(tempDir, "b.env")
+
+	_, err = configFile.WriteString(fmt.Sprintf(`
+[[lease]]
+source = %q
+destination = %q
+duration = "1h"
+lease_type = "env"
+variable = "VAR_A"
+
+[[lease]]
+source = %q
+destination = %q
+duration = "1h"
+lease_type = "env"
+variable = "VAR_B"
+`, sharedSource, destinationA, sharedSource, destinationB))
+	require.NoError(t, err)
+	require.NoError(t, configFile.Close())
+
+	state.Leases["lease-a"] = &config.Lease{
+		Source:      sharedSource,
+		Destination: destinationA,
+		Variable:    "VAR_A",
+		LeaseType:   "env",
+		ConfigFile:  configFile.Name(),
+	}
+	state.Leases["lease-b"] = &config.Lease{
+		Source:      sharedSource,
+		Destination: destinationB,
+		Variable:    "VAR_B",
+		LeaseType:   "env",
+		ConfigFile:  configFile.Name(),
+	}
+
+	err = os.WriteFile(configFile.Name(), []byte(fmt.Sprintf(`
+[[lease]]
+source = %q
+destination = %q
+duration = "1h"
+lease_type = "env"
+variable = "VAR_A"
+`, sharedSource, destinationA)), 0644)
+	require.NoError(t, err)
+
+	daemon.revokeOrphanedLeases()
+
+	assert.Equal(t, 1, revoker.RevokeCount, "only removed sibling lease should be revoked")
+	require.Len(t, revoker.revoked, 1)
+	assert.Equal(t, "VAR_B", revoker.revoked[0].Variable)
+	assert.Equal(t, destinationB, revoker.revoked[0].Destination)
+	assert.Contains(t, state.Leases, "lease-a")
+	assert.NotContains(t, state.Leases, "lease-b")
 }
 
 func TestDaemon_ShutdownRevokesLeasesAndClearsState(t *testing.T) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -240,6 +240,113 @@ variable = "VAR_A"
 	assert.NotContains(t, state.Leases, "lease-b")
 }
 
+func TestDaemon_revokeOrphanedLeases_DoesNotRevokeUnchangedRelativeDestination(t *testing.T) {
+	state := NewState()
+	clock := &mockClock{now: time.Now()}
+	revoker := &mockRevoker{}
+	notifier := &mockNotifier{}
+
+	stateFile, err := os.CreateTemp("", "env-lease-state-*.json")
+	require.NoError(t, err)
+	defer os.Remove(stateFile.Name())
+
+	daemon := NewDaemon(state, stateFile.Name(), clock, nil, revoker, notifier)
+
+	configFile, err := os.CreateTemp("", "env-lease-*.toml")
+	require.NoError(t, err)
+	defer os.Remove(configFile.Name())
+
+	source := "onepassword://vault/item/relative"
+	relativeDestination := ".env"
+	_, err = configFile.WriteString(fmt.Sprintf(`
+[[lease]]
+source = %q
+destination = %q
+duration = "1h"
+lease_type = "env"
+variable = "API_KEY"
+`, source, relativeDestination))
+	require.NoError(t, err)
+	require.NoError(t, configFile.Close())
+
+	state.Leases["relative"] = &config.Lease{
+		Source:      source,
+		Destination: filepath.Join(filepath.Dir(configFile.Name()), relativeDestination),
+		LeaseType:   "env",
+		Variable:    "API_KEY",
+		ConfigFile:  configFile.Name(),
+	}
+
+	daemon.revokeOrphanedLeases()
+
+	assert.Equal(t, 0, revoker.RevokeCount)
+	assert.Contains(t, state.Leases, "relative")
+}
+
+func TestDaemon_revokeOrphanedLeases_PreservesExplodeChildrenWhenConfigUnchanged(t *testing.T) {
+	state := NewState()
+	clock := &mockClock{now: time.Now()}
+	revoker := &mockRevoker{}
+	notifier := &mockNotifier{}
+
+	stateFile, err := os.CreateTemp("", "env-lease-state-*.json")
+	require.NoError(t, err)
+	defer os.Remove(stateFile.Name())
+
+	daemon := NewDaemon(state, stateFile.Name(), clock, nil, revoker, notifier)
+
+	configFile, err := os.CreateTemp("", "env-lease-*.toml")
+	require.NoError(t, err)
+	defer os.Remove(configFile.Name())
+
+	source := "onepassword://vault/item/exploded"
+	relativeDestination := ".env.exploded"
+	_, err = configFile.WriteString(fmt.Sprintf(`
+[[lease]]
+source = %q
+destination = %q
+duration = "1h"
+lease_type = "env"
+transform = ["json", "explode"]
+`, source, relativeDestination))
+	require.NoError(t, err)
+	require.NoError(t, configFile.Close())
+
+	destination := filepath.Join(filepath.Dir(configFile.Name()), relativeDestination)
+	parent := parentLeaseIdentity(source, destination)
+
+	state.Leases["parent"] = &config.Lease{
+		Source:      source,
+		Destination: destination,
+		LeaseType:   "env",
+		Variable:    "",
+		ConfigFile:  configFile.Name(),
+	}
+	state.Leases["child-key1"] = &config.Lease{
+		Source:       source,
+		Destination:  destination,
+		LeaseType:    "env",
+		Variable:     "KEY1",
+		ParentSource: parent,
+		ConfigFile:   configFile.Name(),
+	}
+	state.Leases["child-key2"] = &config.Lease{
+		Source:       source,
+		Destination:  destination,
+		LeaseType:    "env",
+		Variable:     "KEY2",
+		ParentSource: parent,
+		ConfigFile:   configFile.Name(),
+	}
+
+	daemon.revokeOrphanedLeases()
+
+	assert.Equal(t, 0, revoker.RevokeCount)
+	assert.Contains(t, state.Leases, "parent")
+	assert.Contains(t, state.Leases, "child-key1")
+	assert.Contains(t, state.Leases, "child-key2")
+}
+
 func TestDaemon_ShutdownRevokesLeasesAndClearsState(t *testing.T) {
 	tempDir := t.TempDir()
 	socketPath := filepath.Join(os.TempDir(), fmt.Sprintf("env-lease-shutdown-%d.sock", time.Now().UnixNano()))

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -87,7 +87,7 @@ func (d *Daemon) handleGrant(payload []byte) ([]byte, error) {
 			return nil, fmt.Errorf("invalid duration '%s': %w", l.Duration, err)
 		}
 
-		key := fmt.Sprintf("%s;%s;%s", l.Source, l.Destination, l.Variable)
+		key := leaseIdentity(l.Source, l.Destination, l.Variable)
 		lease := &config.Lease{
 			Source:        l.Source,
 			Destination:   l.Destination,
@@ -135,7 +135,7 @@ func (d *Daemon) handleRevoke(payload []byte) ([]byte, error) {
 
 	if len(req.Leases) > 0 {
 		for _, l := range req.Leases {
-			id := fmt.Sprintf("%s;%s;%s", l.Source, l.Destination, l.Variable)
+			id := leaseIdentity(l.Source, l.Destination, l.Variable)
 			if lease, ok := d.state.Leases[id]; ok {
 				slog.Debug("Revoking lease", "source", lease.Source)
 				if lease.LeaseType == "shell" {

--- a/internal/daemon/lease_identity.go
+++ b/internal/daemon/lease_identity.go
@@ -1,0 +1,5 @@
+package daemon
+
+func leaseIdentity(source, destination, variable string) string {
+	return source + ";" + destination + ";" + variable
+}

--- a/internal/daemon/lease_identity.go
+++ b/internal/daemon/lease_identity.go
@@ -1,5 +1,41 @@
 package daemon
 
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/mblarsen/env-lease/internal/config"
+	"github.com/mblarsen/env-lease/internal/fileutil"
+)
+
 func leaseIdentity(source, destination, variable string) string {
 	return source + ";" + destination + ";" + variable
+}
+
+func parentLeaseIdentity(source, destination string) string {
+	return source + "->" + destination
+}
+
+func canonicalLeaseDestination(root string, lease config.Lease) (string, error) {
+	if lease.LeaseType == "shell" {
+		return filepath.Join(root, "<shell>"), nil
+	}
+
+	destination, err := fileutil.ExpandPath(lease.Destination)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(destination) {
+		destination = filepath.Join(root, destination)
+	}
+	return destination, nil
+}
+
+func hasExplodeTransform(transforms []string) bool {
+	for _, t := range transforms {
+		if strings.HasPrefix(strings.TrimSpace(t), "explode") {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- fix orphaned-lease reconciliation in `internal/daemon/daemon.go` to match leases by stable identity (source + destination + variable) instead of source only
- ensure sibling leases sharing the same source are correctly revoked when one is removed from config
- add a shared lease identity helper and reuse it in daemon handlers for consistent keying

## Tests
- go test ./internal/daemon
- go test ./...