### PR TITLE
fix: keep all interactive lease selections with duplicate labels

### DIFF
--- a/cmd/grant.go
+++ b/cmd/grant.go
@@ -698,9 +698,7 @@ func getTransformSummary(transforms []string) string {
 func interactiveGrant(cmd *cobra.Command, cfg *config.Config, absConfigFile string, client *ipc.Client) error {
 	slog.Debug("interactive grant: phase 1 start", "lease_count", len(cfg.Lease))
 	// ------- Phase 1: ROUND 1 – APPROVE SOURCES -------
-	options := make([]string, 0, len(cfg.Lease))
-	leaseMap := make(map[string]config.Lease, len(cfg.Lease))
-
+	selectedLeases := make([]config.Lease, 0, len(cfg.Lease))
 	for _, l := range cfg.Lease {
 		isExplode := hasExplode(l.Transform)
 
@@ -714,30 +712,19 @@ func interactiveGrant(cmd *cobra.Command, cfg *config.Config, absConfigFile stri
 			key = fmt.Sprintf("'%s'", l.Source)
 		}
 
-		options = append(options, key)
-		leaseMap[key] = l
-	}
-
-	selectedLeaseKeys := make([]string, 0, len(options))
-	for _, opt := range options {
-		if confirm(fmt.Sprintf("Grant %s?", opt)) {
-			selectedLeaseKeys = append(selectedLeaseKeys, opt)
+		if confirm(fmt.Sprintf("Grant %s?", key)) {
+			selectedLeases = append(selectedLeases, l)
 		}
 	}
 
-	if len(selectedLeaseKeys) == 0 {
+	if len(selectedLeases) == 0 {
 		fmt.Fprintln(os.Stderr, "No leases selected.")
 		return nil
 	}
 
 	slog.Debug("interactive grant: phase 1 approvals",
-		"selected_count", len(selectedLeaseKeys),
-		"skipped_count", len(cfg.Lease)-len(selectedLeaseKeys))
-
-	selectedLeases := make([]config.Lease, 0, len(selectedLeaseKeys))
-	for _, key := range selectedLeaseKeys {
-		selectedLeases = append(selectedLeases, leaseMap[key])
-	}
+		"selected_count", len(selectedLeases),
+		"skipped_count", len(cfg.Lease)-len(selectedLeases))
 
 	continueOnError, _ := cmd.Flags().GetBool("continue-on-error")
 	override, _ := cmd.Flags().GetBool("override")

--- a/cmd/grant_interactive_test.go
+++ b/cmd/grant_interactive_test.go
@@ -82,6 +82,52 @@ duration = "1m"
 		assert.True(t, os.IsNotExist(err), "destination file should not be created")
 	})
 
+	t.Run("interactive mode duplicate prompt labels", func(t *testing.T) {
+		destFileOne := filepath.Join(tempDir, ".env.duplicate.one")
+		destFileTwo := filepath.Join(tempDir, ".env.duplicate.two")
+		configContent := `
+[[lease]]
+source = "mock-duplicate-1"
+destination = "` + destFileOne + `"
+variable = "API_KEY"
+duration = "1m"
+format = "%s=%q"
+
+[[lease]]
+source = "mock-duplicate-2"
+destination = "` + destFileTwo + `"
+variable = "API_KEY"
+duration = "1m"
+format = "%s=%q"
+`
+		configFile := writeConfig(configContent)
+		grantCmd.Flags().Set("config", configFile)
+		grantCmd.Flags().Set("interactive", "true")
+
+		apiKeyPromptCount := 0
+		originalConfirm := confirm
+		defer func() { confirm = originalConfirm }()
+		resetConfirmState()
+		confirm = func(prompt string) bool {
+			if prompt == "Grant 'API_KEY'?" {
+				apiKeyPromptCount++
+			}
+			return true
+		}
+
+		err := grantCmd.RunE(grantCmd, []string{})
+		assert.NoError(t, err, "grant command failed")
+		assert.Equal(t, 2, apiKeyPromptCount, "expected duplicate prompt label to be shown for each lease")
+
+		contentOne, err := os.ReadFile(destFileOne)
+		assert.NoError(t, err, "failed to read first destination file")
+		assert.Contains(t, string(contentOne), `API_KEY="secret-for-mock-duplicate-1"`)
+
+		contentTwo, err := os.ReadFile(destFileTwo)
+		assert.NoError(t, err, "failed to read second destination file")
+		assert.Contains(t, string(contentTwo), `API_KEY="secret-for-mock-duplicate-2"`)
+	})
+
 	t.Run("interactive mode multi-phase flow", func(t *testing.T) {
 		destFileSimple := filepath.Join(tempDir, ".env.simple")
 		destFileExplode := filepath.Join(tempDir, ".env.explode")


### PR DESCRIPTION
## Summary
- fix interactive grant selection to record approvals by lease entry instead of a map keyed by prompt label
- prevent duplicate labels (for example two leases with the same variable name) from dropping a selected lease
- keep behavior unchanged outside this minimal interactive selection fix

## Tests
- `go test ./cmd -run TestGrantRunE_Interactive`
- `go test ./...`
- added `interactive mode duplicate prompt labels` in `cmd/grant_interactive_test.go`
