### PR TITLE
ci: read Go version from go.mod in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.3'
+          go-version-file: go.mod
 
       - name: configure git for private modules
         run: git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadof "https://github.com/"


### PR DESCRIPTION
## Summary
Use `go.mod` as the single source of truth for the Go version in the release workflow.

## Change
In `.github/workflows/release.yml`, update `actions/setup-go` to read from `go.mod`:

- from: `go-version: '1.24.3'`
- to: `go-version-file: go.mod`

## Why
This prevents version drift between workflow config and module metadata, while preserving existing release behavior.

## Scope
- Focused CI-only change
- Only `.github/workflows/release.yml` modified
- No other workflow logic changed

## Validation
- `git diff -- .github/workflows/release.yml`
- `git status --short` (showed only the intended workflow file before commit)
