### PR TITLE
fix: recover daemon startup from corrupt state file

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -85,7 +85,10 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		state := loadDaemonState(statePath)
+		state, err := loadDaemonState(statePath)
+		if err != nil {
+			return err
+		}
 
 		// Set up dependencies
 		clock := &daemon.RealClock{}
@@ -104,15 +107,18 @@ var runCmd = &cobra.Command{
 	},
 }
 
-func loadDaemonState(statePath string) *daemon.State {
+func loadDaemonState(statePath string) (*daemon.State, error) {
 	state, err := daemon.LoadState(statePath)
 	if err != nil {
-		slog.Warn("Failed to load daemon state; starting with empty state", "path", statePath, "err", err)
-		return daemon.NewState()
+		if daemon.IsCorruptStateError(err) {
+			slog.Warn("State file is malformed; starting with empty state", "path", statePath, "err", err)
+			return daemon.NewState(), nil
+		}
+		return nil, fmt.Errorf("failed to load daemon state: %w", err)
 	}
 
 	slog.Info("Loaded state", "leases", len(state.Leases))
-	return state
+	return state, nil
 }
 
 var cleanupCmd = &cobra.Command{

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -85,13 +85,7 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		// Load state
-		state, err := daemon.LoadState(statePath)
-		if err != nil {
-			slog.Warn("No state file found, initializing new state.")
-		} else {
-			slog.Info("Loaded state", "leases", len(state.Leases))
-		}
+		state := loadDaemonState(statePath)
 
 		// Set up dependencies
 		clock := &daemon.RealClock{}
@@ -108,6 +102,17 @@ var runCmd = &cobra.Command{
 
 		return d.Run(context.Background())
 	},
+}
+
+func loadDaemonState(statePath string) *daemon.State {
+	state, err := daemon.LoadState(statePath)
+	if err != nil {
+		slog.Warn("Failed to load daemon state; starting with empty state", "path", statePath, "err", err)
+		return daemon.NewState()
+	}
+
+	slog.Info("Loaded state", "leases", len(state.Leases))
+	return state
 }
 
 var cleanupCmd = &cobra.Command{

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mblarsen/env-lease/internal/config"
+	"github.com/mblarsen/env-lease/internal/daemon"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadDaemonStateFallsBackToEmptyStateOnCorruption(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	require.NoError(t, os.WriteFile(statePath, []byte("{"), 0600))
+
+	state := loadDaemonState(statePath)
+
+	require.NotNil(t, state)
+	assert.Empty(t, state.Leases)
+	assert.Empty(t, state.RetryQueue)
+}
+
+func TestLoadDaemonStateReturnsPersistedStateWhenValid(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+
+	expected := daemon.NewState()
+	expected.Leases["lease1"] = &config.Lease{
+		Source:    "onepassword://vault/item/field",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	require.NoError(t, expected.SaveState(statePath))
+
+	loaded := loadDaemonState(statePath)
+
+	require.NotNil(t, loaded)
+	require.Contains(t, loaded.Leases, "lease1")
+	assert.Equal(t, expected.Leases["lease1"].Source, loaded.Leases["lease1"].Source)
+}

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -16,8 +16,9 @@ func TestLoadDaemonStateFallsBackToEmptyStateOnCorruption(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	require.NoError(t, os.WriteFile(statePath, []byte("{"), 0600))
 
-	state := loadDaemonState(statePath)
+	state, err := loadDaemonState(statePath)
 
+	require.NoError(t, err)
 	require.NotNil(t, state)
 	assert.Empty(t, state.Leases)
 	assert.Empty(t, state.RetryQueue)
@@ -33,9 +34,21 @@ func TestLoadDaemonStateReturnsPersistedStateWhenValid(t *testing.T) {
 	}
 	require.NoError(t, expected.SaveState(statePath))
 
-	loaded := loadDaemonState(statePath)
+	loaded, err := loadDaemonState(statePath)
 
+	require.NoError(t, err)
 	require.NotNil(t, loaded)
 	require.Contains(t, loaded.Leases, "lease1")
 	assert.Equal(t, expected.Leases["lease1"].Source, loaded.Leases["lease1"].Source)
+}
+
+func TestLoadDaemonStateReturnsErrorForUnreadableState(t *testing.T) {
+	statePath := t.TempDir()
+
+	state, err := loadDaemonState(statePath)
+
+	require.Error(t, err)
+	assert.Nil(t, state)
+	assert.Contains(t, err.Error(), "failed to load daemon state")
+	assert.NotContains(t, err.Error(), "malformed")
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -46,7 +46,7 @@ type Daemon struct {
 // NewDaemon creates a new daemon.
 func NewDaemon(state *State, statePath string, clock Clock, ipcServer *ipc.Server, revoker Revoker, notifier Notifier) *Daemon {
 	return &Daemon{
-		state:     state,
+		state:     normalizeState(state),
 		statePath: statePath,
 		clock:     clock,
 		ipcServer: ipcServer,

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -56,6 +56,17 @@ func TestDaemon_Run(t *testing.T) {
 	}
 }
 
+func TestNewDaemon_InitializesStateWhenNil(t *testing.T) {
+	d := NewDaemon(nil, "/dev/null", &mockClock{now: time.Now()}, nil, &mockRevoker{}, nil)
+
+	require.NotNil(t, d.state)
+	assert.NotNil(t, d.state.Leases)
+	assert.NotNil(t, d.state.RetryQueue)
+	assert.NotPanics(t, func() {
+		d.revokeExpiredLeases()
+	})
+}
+
 func TestDaemon_revokeExpiredLeases(t *testing.T) {
 	// Arrange
 	state := NewState()

--- a/internal/daemon/state.go
+++ b/internal/daemon/state.go
@@ -32,6 +32,19 @@ func NewState() *State {
 	}
 }
 
+func normalizeState(state *State) *State {
+	if state == nil {
+		return NewState()
+	}
+	if state.Leases == nil {
+		state.Leases = make(map[string]*config.Lease)
+	}
+	if state.RetryQueue == nil {
+		state.RetryQueue = make([]RetryItem, 0)
+	}
+	return state
+}
+
 // LoadState loads the daemon state from a file.
 func LoadState(path string) (*State, error) {
 	data, err := os.ReadFile(path)
@@ -50,7 +63,7 @@ func LoadState(path string) (*State, error) {
 	if err := json.Unmarshal(data, &state); err != nil {
 		return nil, err
 	}
-	return &state, nil
+	return normalizeState(&state), nil
 }
 
 // SaveState saves the daemon state to a file.

--- a/internal/daemon/state.go
+++ b/internal/daemon/state.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -24,12 +25,20 @@ type RetryItem struct {
 	InitialFailure time.Time     `json:"initial_failure"`
 }
 
+// ErrMalformedState indicates the state file contains invalid JSON payload data.
+var ErrMalformedState = errors.New("malformed daemon state file")
+
 // NewState creates a new, empty state.
 func NewState() *State {
 	return &State{
 		Leases:     make(map[string]*config.Lease),
 		RetryQueue: make([]RetryItem, 0),
 	}
+}
+
+// IsCorruptStateError reports whether an error is caused by malformed state content.
+func IsCorruptStateError(err error) bool {
+	return errors.Is(err, ErrMalformedState)
 }
 
 func normalizeState(state *State) *State {
@@ -61,7 +70,7 @@ func LoadState(path string) (*State, error) {
 
 	var state State
 	if err := json.Unmarshal(data, &state); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", ErrMalformedState, err)
 	}
 	return normalizeState(&state), nil
 }

--- a/internal/daemon/state_test.go
+++ b/internal/daemon/state_test.go
@@ -57,5 +57,18 @@ func TestState(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected an error, got nil")
 		}
+		if !IsCorruptStateError(err) {
+			t.Fatalf("expected malformed-state error, got: %v", err)
+		}
+	})
+
+	t.Run("load read failure is not corrupt", func(t *testing.T) {
+		_, err := LoadState(dir)
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if IsCorruptStateError(err) {
+			t.Fatalf("expected non-corrupt read error, got: %v", err)
+		}
 	})
 }


### PR DESCRIPTION
## Summary
- fallback to an empty daemon state when startup cannot load state.json
- normalize daemon state in NewDaemon so nil state pointers and nil collections cannot panic runtime loops
- add regression tests for corrupt-state fallback and nil-state daemon initialization

## Validation
- go test ./...
- manual repro with malformed state file ({) now logs a warning and daemon starts without panic
