### PR TITLE
fix: prevent test-mode nil IPC client panics

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -116,6 +116,11 @@ var cleanupCmd = &cobra.Command{
 	Long:  `Cleanup orphaned leases.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client := newIPCClient()
+		if client == nil {
+			fmt.Println("Cleanup command running in test mode.")
+			return nil
+		}
+
 		req := ipc.CleanupRequest{Command: "cleanup"}
 		var resp ipc.CleanupResponse
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -18,6 +18,11 @@ var statusCmd = &cobra.Command{
 	Long:  `Show the status of active leases.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client := newIPCClient()
+		if client == nil {
+			fmt.Println("Status command running in test mode.")
+			return nil
+		}
+
 		req := ipc.StatusRequest{Command: "status"}
 		var resp ipc.StatusResponse
 		if err := client.Send(req, &resp); err != nil {

--- a/cmd/testmode_client_test.go
+++ b/cmd/testmode_client_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close stdout writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read stdout: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("failed to close stdout reader: %v", err)
+	}
+	return string(out)
+}
+
+func TestStatusCommandTestModeNoPanic(t *testing.T) {
+	t.Setenv("ENV_LEASE_TEST", "1")
+
+	var runErr error
+	output := captureStdout(t, func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("status command panicked in test mode: %v", r)
+			}
+		}()
+
+		runErr = statusCmd.RunE(statusCmd, []string{})
+	})
+
+	if runErr != nil {
+		t.Fatalf("status command returned error in test mode: %v", runErr)
+	}
+	if !strings.Contains(output, "Status command running in test mode.") {
+		t.Fatalf("expected test mode status message, got %q", output)
+	}
+}
+
+func TestDaemonCleanupCommandTestModeNoPanic(t *testing.T) {
+	t.Setenv("ENV_LEASE_TEST", "1")
+
+	var runErr error
+	output := captureStdout(t, func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("daemon cleanup command panicked in test mode: %v", r)
+			}
+		}()
+
+		runErr = cleanupCmd.RunE(cleanupCmd, []string{})
+	})
+
+	if runErr != nil {
+		t.Fatalf("daemon cleanup returned error in test mode: %v", runErr)
+	}
+	if !strings.Contains(output, "Cleanup command running in test mode.") {
+		t.Fatalf("expected test mode cleanup message, got %q", output)
+	}
+}


### PR DESCRIPTION
## Summary
- add nil client guards in `status` and `daemon cleanup` when `ENV_LEASE_TEST=1`
- return early with explicit test-mode messages instead of calling `Send` on a nil client
- add regression tests for both command paths to ensure no panic in test mode

## Validation
- `go test ./...`
- `ENV_LEASE_TEST=1 go run ./cmd/env-lease status`
- `ENV_LEASE_TEST=1 go run ./cmd/env-lease daemon cleanup`
