### PR TITLE
fix: block symlink escapes in destination root validation

### DIFF
--- a/cmd/grant.go
+++ b/cmd/grant.go
@@ -622,6 +622,8 @@ func processLease(cmd *cobra.Command, l config.Lease, secretVal, projectRoot, co
 		}
 		if !filepath.IsAbs(absDest) {
 			absDest = filepath.Join(projectRoot, absDest)
+		} else {
+			absDest = filepath.Clean(absDest)
 		}
 	}
 

--- a/cmd/grant_security_test.go
+++ b/cmd/grant_security_test.go
@@ -114,7 +114,31 @@ duration = "1h"
 		t.Errorf("Did not expect an error, but got: %v\nStderr: %s", err, stderr)
 	}
 
-	// Test case 3: Destination inside root (should succeed)
+	// Test case 3: Destination through symlink in root that points outside (should fail)
+	outsideLink := filepath.Join(projectRoot, "outside-link")
+	if err := os.Symlink(outsideDir, outsideLink); err != nil {
+		t.Skipf("Symlinks not supported on this platform: %v", err)
+	}
+	symlinkDestination := filepath.Join(outsideLink, "secret-via-link")
+	configContent = fmt.Sprintf(`
+[[lease]]
+lease_type = "file"
+source = "op://vault/item/field"
+destination = "%s"
+duration = "1h"
+`, symlinkDestination)
+	os.WriteFile(configFile, []byte(configContent), 0644)
+
+	_, _, err = runGrantCommand(t, "--config", configFile, "--destination-outside-root=false", "--interactive=false")
+	if err == nil {
+		t.Error("Expected an error for symlink escape, but got none")
+	}
+	expectedSymlinkError := fmt.Sprintf("destination path '%s' is outside the project root", symlinkDestination)
+	if err != nil && !strings.Contains(err.Error(), expectedSymlinkError) {
+		t.Errorf("Expected error message to contain '%s', but it was: %s", expectedSymlinkError, err.Error())
+	}
+
+	// Test case 4: Destination inside root (should succeed)
 	configContent = fmt.Sprintf(`
 [[lease]]
 lease_type = "file"
@@ -129,7 +153,7 @@ duration = "1h"
 		t.Errorf("Did not expect an error, but got: %v\nStderr: %s", err, stderr)
 	}
 
-	// Test case 4: Exploded lease, check for empty unset in revoke
+	// Test case 5: Exploded lease, check for empty unset in revoke
 	configContent = `
 [[lease]]
 lease_type = "shell"

--- a/cmd/writer.go
+++ b/cmd/writer.go
@@ -17,6 +17,8 @@ func writeLease(l config.Lease, secretVal, projectRoot string, override bool) (b
 	dest := l.Destination
 	if !filepath.IsAbs(dest) {
 		dest = filepath.Join(projectRoot, dest)
+	} else {
+		dest = filepath.Clean(dest)
 	}
 
 	if _, err := os.Stat(dest); os.IsNotExist(err) {

--- a/internal/daemon/lease_identity.go
+++ b/internal/daemon/lease_identity.go
@@ -27,6 +27,8 @@ func canonicalLeaseDestination(root string, lease config.Lease) (string, error) 
 	}
 	if !filepath.IsAbs(destination) {
 		destination = filepath.Join(root, destination)
+	} else {
+		destination = filepath.Clean(destination)
 	}
 	return destination, nil
 }

--- a/internal/fileutil/path_validation.go
+++ b/internal/fileutil/path_validation.go
@@ -39,12 +39,20 @@ func IsPathInsideRoot(root, path string) (bool, error) {
 	}
 
 	// Clean the path before symlink resolution so that .. segments are
-	// resolved lexically first, matching the behaviour of writeLease which
-	// uses filepath.Join (and therefore filepath.Clean) to build the
-	// destination. Without this, a path like link/../secret would be
-	// resolved through the symlink at "link" and the .. would ascend from
-	// the symlink target, producing a false-positive denial even though
-	// filepath.Join would have cancelled link/.. and written inside root.
+	// resolved lexically first. This matches writeLease, processLease,
+	// and canonicalLeaseDestination, which all use filepath.Join (for
+	// relative paths, which calls Clean internally) or filepath.Clean
+	// (for absolute paths) to build the destination.
+	//
+	// Without this, a path like link/../secret would be resolved through
+	// the symlink at "link" and the .. would ascend from the symlink
+	// target, producing a false-positive denial even though filepath.Join
+	// would have cancelled link/.. and written inside root.
+	//
+	// Security: because both validation and write paths clean before
+	// resolving, a symlink/.. pattern is cancelled on both sides.
+	// Symlink escapes without .. (e.g. outside_link/secret) are still
+	// caught by resolvePathAllowMissing following the symlink target.
 	if !filepath.IsAbs(expandedPath) {
 		expandedPath = filepath.Join(absRoot, expandedPath)
 	} else {

--- a/internal/fileutil/path_validation.go
+++ b/internal/fileutil/path_validation.go
@@ -38,8 +38,17 @@ func IsPathInsideRoot(root, path string) (bool, error) {
 		return false, fmt.Errorf("could not resolve root path '%s': %w", absRoot, err)
 	}
 
+	// Clean the path before symlink resolution so that .. segments are
+	// resolved lexically first, matching the behaviour of writeLease which
+	// uses filepath.Join (and therefore filepath.Clean) to build the
+	// destination. Without this, a path like link/../secret would be
+	// resolved through the symlink at "link" and the .. would ascend from
+	// the symlink target, producing a false-positive denial even though
+	// filepath.Join would have cancelled link/.. and written inside root.
 	if !filepath.IsAbs(expandedPath) {
-		expandedPath = joinPathPreserve(absRoot, expandedPath)
+		expandedPath = filepath.Join(absRoot, expandedPath)
+	} else {
+		expandedPath = filepath.Clean(expandedPath)
 	}
 
 	resolvedPath, err := resolvePathAllowMissing(expandedPath)
@@ -62,16 +71,6 @@ func IsPathInsideRoot(root, path string) (bool, error) {
 	}
 
 	return true, nil
-}
-
-func joinPathPreserve(base, rel string) string {
-	if rel == "" {
-		return base
-	}
-	if strings.HasSuffix(base, string(os.PathSeparator)) {
-		return base + rel
-	}
-	return base + string(os.PathSeparator) + rel
 }
 
 func resolvePathAllowMissing(path string) (string, error) {

--- a/internal/fileutil/path_validation.go
+++ b/internal/fileutil/path_validation.go
@@ -20,12 +20,9 @@ func ExpandPath(path string) (string, error) {
 }
 
 // IsPathInsideRoot checks if the given path is within the root directory.
-// Both paths are expected to be absolute paths.
+// Symlinks are resolved for existing path components to enforce true
+// filesystem containment instead of lexical containment.
 func IsPathInsideRoot(root, path string) (bool, error) {
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(root, path)
-	}
-
 	expandedPath, err := ExpandPath(path)
 	if err != nil {
 		return false, fmt.Errorf("could not expand path '%s': %w", path, err)
@@ -36,22 +33,115 @@ func IsPathInsideRoot(root, path string) (bool, error) {
 		return false, fmt.Errorf("could not get absolute path for root '%s': %w", root, err)
 	}
 
-	absPath, err := filepath.Abs(expandedPath)
+	resolvedRoot, err := filepath.EvalSymlinks(absRoot)
 	if err != nil {
-		return false, fmt.Errorf("could not get absolute path for path '%s': %w", expandedPath, err)
+		return false, fmt.Errorf("could not resolve root path '%s': %w", absRoot, err)
+	}
+
+	if !filepath.IsAbs(expandedPath) {
+		expandedPath = joinPathPreserve(absRoot, expandedPath)
+	}
+
+	resolvedPath, err := resolvePathAllowMissing(expandedPath)
+	if err != nil {
+		return false, fmt.Errorf("could not resolve path '%s': %w", expandedPath, err)
 	}
 
 	// On Windows, drive letters must match.
-	if filepath.VolumeName(absRoot) != filepath.VolumeName(absPath) {
+	if filepath.VolumeName(resolvedRoot) != filepath.VolumeName(resolvedPath) {
 		return false, nil
 	}
 
-	rel, err := filepath.Rel(absRoot, absPath)
+	rel, err := filepath.Rel(resolvedRoot, resolvedPath)
 	if err != nil {
 		return false, fmt.Errorf("could not get relative path: %w", err)
 	}
 
-	// If the relative path starts with '..', it's outside the root.
-	// This also handles the case where the paths are the same (rel is '.').
-	return !strings.HasPrefix(rel, ".."), nil
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func joinPathPreserve(base, rel string) string {
+	if rel == "" {
+		return base
+	}
+	if strings.HasSuffix(base, string(os.PathSeparator)) {
+		return base + rel
+	}
+	return base + string(os.PathSeparator) + rel
+}
+
+func resolvePathAllowMissing(path string) (string, error) {
+	current := path
+	missingParts := make([]string, 0, 4)
+
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			for i := len(missingParts) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missingParts[i])
+			}
+			return resolved, nil
+		}
+
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+
+		parent, component, ok := splitPathPreserve(current)
+		if !ok {
+			return "", err
+		}
+
+		missingParts = append(missingParts, component)
+		current = parent
+	}
+}
+
+func splitPathPreserve(path string) (parent, component string, ok bool) {
+	if path == "" {
+		return "", "", false
+	}
+
+	volume := filepath.VolumeName(path)
+	volumeLen := len(volume)
+	end := len(path)
+
+	for end > volumeLen+1 && os.IsPathSeparator(path[end-1]) {
+		end--
+	}
+
+	if end <= volumeLen+1 {
+		if len(path) > volumeLen && os.IsPathSeparator(path[volumeLen]) {
+			return "", "", false
+		}
+	}
+
+	idx := end - 1
+	for idx >= volumeLen && !os.IsPathSeparator(path[idx]) {
+		idx--
+	}
+
+	if idx < volumeLen {
+		if filepath.IsAbs(path) {
+			return volume + string(os.PathSeparator), path[volumeLen:end], true
+		}
+		return ".", path[:end], true
+	}
+
+	component = path[idx+1 : end]
+	if idx == volumeLen {
+		parent = path[:idx+1]
+	} else {
+		parent = path[:idx]
+	}
+
+	if parent == "" {
+		parent = "."
+	}
+
+	return parent, component, true
 }

--- a/internal/fileutil/path_validation_test.go
+++ b/internal/fileutil/path_validation_test.go
@@ -106,14 +106,77 @@ func TestIsPathInsideRoot_SymlinkEscape(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "Symlink traversal with dotdot escaping root is rejected",
+			name:     "Symlink canceled by dotdot is allowed (path cleans inside root)",
 			path:     outsideLink + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "escaped.txt",
-			expected: false,
+			expected: true,
 		},
 		{
 			name:     "Symlink to inside root is allowed",
 			path:     filepath.Join(insideLink, "secret.txt"),
 			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inside, err := IsPathInsideRoot(rootDir, tc.path)
+			if err != nil {
+				t.Fatalf("did not expect error: %v", err)
+			}
+			if inside != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, inside)
+			}
+		})
+	}
+}
+
+func TestIsPathInsideRoot_DotDotCancelsSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	rootDir := filepath.Join(tmpDir, "root")
+	outsideDir := filepath.Join(tmpDir, "outside")
+
+	if err := os.MkdirAll(rootDir, 0o755); err != nil {
+		t.Fatalf("failed to create root dir: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("failed to create outside dir: %v", err)
+	}
+
+	// outside-link is a symlink inside root that points outside root
+	outsideLink := filepath.Join(rootDir, "outside-link")
+	if err := os.Symlink(outsideDir, outsideLink); err != nil {
+		t.Skipf("symlink not supported on this platform: %v", err)
+	}
+
+	testCases := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "Relative link/../secret is allowed when dotdot cancels symlink",
+			path:     filepath.Join("outside-link", "..", "secret.txt"),
+			expected: true,
+		},
+		{
+			name:     "Relative link/secret is still rejected (symlink escape)",
+			path:     filepath.Join("outside-link", "secret.txt"),
+			expected: false,
+		},
+		{
+			name:     "Relative link/../../escape is rejected",
+			path:     filepath.Join("outside-link", "..", "..", "escape.txt"),
+			expected: false,
+		},
+		{
+			name:     "Absolute link/../secret is allowed",
+			path:     filepath.Join(outsideLink, "..", "secret.txt"),
+			expected: true,
+		},
+		{
+			name:     "Absolute link/secret is rejected (symlink escape)",
+			path:     filepath.Join(outsideLink, "secret.txt"),
+			expected: false,
 		},
 	}
 

--- a/internal/fileutil/path_validation_test.go
+++ b/internal/fileutil/path_validation_test.go
@@ -7,90 +7,124 @@ import (
 )
 
 func TestIsPathInsideRoot(t *testing.T) {
-	// Create temporary directories for testing
 	tmpDir := t.TempDir()
 	rootDir := filepath.Join(tmpDir, "root")
 	insideDir := filepath.Join(rootDir, "inside")
 	outsideDir := filepath.Join(tmpDir, "outside")
 
-	if err := os.MkdirAll(insideDir, 0755); err != nil {
-		t.Fatalf("Failed to create test directories: %v", err)
+	if err := os.MkdirAll(insideDir, 0o755); err != nil {
+		t.Fatalf("failed to create inside dir: %v", err)
 	}
-	if err := os.MkdirAll(outsideDir, 0755); err != nil {
-		t.Fatalf("Failed to create test directories: %v", err)
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("failed to create outside dir: %v", err)
 	}
 
 	testCases := []struct {
-		name        string
-		root        string
-		path        string
-		expected    bool
-		expectError bool
+		name     string
+		path     string
+		expected bool
 	}{
 		{
 			name:     "Path inside root",
-			root:     rootDir,
-			path:     filepath.Join(rootDir, "some", "path"),
+			path:     filepath.Join(rootDir, "inside", "some", "path"),
 			expected: true,
 		},
 		{
 			name:     "Path is the root",
-			root:     rootDir,
 			path:     rootDir,
 			expected: true,
 		},
 		{
 			name:     "Path outside root",
-			root:     rootDir,
 			path:     filepath.Join(outsideDir, "some", "path"),
 			expected: false,
 		},
 		{
-			name:     "Path is a sibling of root",
-			root:     rootDir,
-			path:     outsideDir,
-			expected: false,
-		},
-		{
-			name:     "Path is a parent of root",
-			root:     rootDir,
-			path:     tmpDir,
-			expected: false,
-		},
-		{
 			name:     "Relative path inside root",
-			root:     rootDir,
-			path:     filepath.Join(rootDir, "."),
+			path:     filepath.Join("inside", "nested", "file.txt"),
 			expected: true,
 		},
 		{
-			name:     "Relative path going outside root",
-			root:     rootDir,
-			path:     filepath.Join(rootDir, ".."),
+			name:     "Relative path escaping root",
+			path:     filepath.Join("..", "outside", "file.txt"),
 			expected: false,
+		},
+		{
+			name:     "Non-existent path inside root with existing parent",
+			path:     filepath.Join(rootDir, "inside", "new-file.txt"),
+			expected: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Need to import "os"
-			if err := os.MkdirAll(filepath.Dir(tc.path), 0755); err != nil {
-				t.Fatalf("Failed to create test directories for path %s: %v", tc.path, err)
+			inside, err := IsPathInsideRoot(rootDir, tc.path)
+			if err != nil {
+				t.Fatalf("did not expect error: %v", err)
 			}
+			if inside != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, inside)
+			}
+		})
+	}
+}
 
-			inside, err := IsPathInsideRoot(tc.root, tc.path)
+func TestIsPathInsideRoot_SymlinkEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	rootDir := filepath.Join(tmpDir, "root")
+	outsideDir := filepath.Join(tmpDir, "outside")
+	insideTargetDir := filepath.Join(rootDir, "real-inside")
 
-			if tc.expectError {
-				if err == nil {
-					t.Errorf("Expected an error, but got none")
-				}
-			} else {
-				if err != nil {
-					t.Errorf("Did not expect an error, but got: %v", err)
-				}
-				if inside != tc.expected {
-					t.Errorf("Expected %v, but got %v", tc.expected, inside)
-				}
+	if err := os.MkdirAll(rootDir, 0o755); err != nil {
+		t.Fatalf("failed to create root dir: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("failed to create outside dir: %v", err)
+	}
+	if err := os.MkdirAll(insideTargetDir, 0o755); err != nil {
+		t.Fatalf("failed to create inside target dir: %v", err)
+	}
+
+	outsideLink := filepath.Join(rootDir, "outside-link")
+	if err := os.Symlink(outsideDir, outsideLink); err != nil {
+		t.Skipf("symlink not supported on this platform: %v", err)
+	}
+
+	insideLink := filepath.Join(rootDir, "inside-link")
+	if err := os.Symlink(insideTargetDir, insideLink); err != nil {
+		t.Skipf("symlink not supported on this platform: %v", err)
+	}
+
+	testCases := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "Symlink to outside root is rejected",
+			path:     filepath.Join(outsideLink, "secret.txt"),
+			expected: false,
+		},
+		{
+			name:     "Symlink traversal with dotdot escaping root is rejected",
+			path:     outsideLink + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "escaped.txt",
+			expected: false,
+		},
+		{
+			name:     "Symlink to inside root is allowed",
+			path:     filepath.Join(insideLink, "secret.txt"),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inside, err := IsPathInsideRoot(rootDir, tc.path)
+			if err != nil {
+				t.Fatalf("did not expect error: %v", err)
+			}
+			if inside != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, inside)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- harden `internal/fileutil/IsPathInsideRoot` to enforce real filesystem containment by resolving symlinks
- support non-existent destination files by resolving the nearest existing ancestor and rebuilding remaining path components
- add regression coverage for symlink escapes in both fileutil unit tests and grant command security tests

## Validation
- `go test ./...`
