### PR TITLE
refactor: deepen secret lookup

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,10 @@ _Avoid_: target, output, sink
 The external secret store or CLI that resolves a Secret source into Secret material.
 _Avoid_: backend, vault, service
 
+**Secret Lookup**:
+The act of resolving an approved Lease's Secret source through a Provider before Grant materializes it.
+_Avoid_: provider fetch, backend lookup, source read
+
 **Daemon**:
 The background process that owns active Lease state and performs scheduled revocation.
 _Avoid_: worker, server, scheduler
@@ -40,14 +44,15 @@ _Avoid_: manifest, spec, settings
 
 - A **Config** declares zero or more **Leases**.
 - A **Lease** identifies exactly one **Secret** source and one **Destination**.
-- A **Provider** resolves a **Secret** source during **Grant**.
+- A **Provider** performs **Secret Lookup** for an approved **Lease**.
+- A **Grant** uses **Secret Lookup** before materializing a **Secret** at its **Destination**.
 - A **Grant** registers a **Lease** with the **Daemon**.
 - The **Daemon** performs **Revoke** when a **Lease** expires or is removed from **Config**.
 
 ## Example dialogue
 
-> **Dev:** "When I run **Grant**, does every **Secret** get fetched immediately?"
-> **Domain expert:** "Only approved **Leases** should fetch their **Secret**, then the **Daemon** tracks when each **Lease** should **Revoke** its **Destination**."
+> **Dev:** "When I run **Grant**, does every **Secret** go through **Secret Lookup** immediately?"
+> **Domain expert:** "Only approved **Leases** should perform **Secret Lookup**, then the **Daemon** tracks when each **Lease** should **Revoke** its **Destination**."
 
 ## Flagged ambiguities
 

--- a/cmd/grant.go
+++ b/cmd/grant.go
@@ -71,17 +71,15 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/mblarsen/env-lease/internal/config"
 	"github.com/mblarsen/env-lease/internal/fileutil"
 	"github.com/mblarsen/env-lease/internal/ipc"
 	"github.com/mblarsen/env-lease/internal/lease"
-	"github.com/mblarsen/env-lease/internal/provider"
+	"github.com/mblarsen/env-lease/internal/secretlookup"
 	"github.com/mblarsen/env-lease/internal/transform"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 )
 
 var shellMode bool
@@ -143,15 +141,17 @@ func processSingleLease(cmd *cobra.Command, l lease.Lease, secretVal string, pro
 		// Fetch secret if not already fetched
 		if secretVal == "" {
 			slog.Info("Fetching secret", "source", l.Source)
-			var p provider.SecretProvider
-			if os.Getenv("ENV_LEASE_TEST") == "1" {
-				p = &provider.MockProvider{}
-			} else {
-				p = &provider.OnePasswordCLI{Account: l.OpAccount}
+			secrets, lookupErrs, err := secretlookup.Fetch([]lease.Lease{l}, secretlookup.Options{})
+			if len(lookupErrs) > 0 {
+				return nil, nil, fmt.Errorf("failed to fetch secret: %w", lookupErrs[0].Err)
 			}
-			secretVal, err = p.Fetch(l.Source)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to fetch secret: %w", err)
+			}
+			var ok bool
+			secretVal, ok = secrets.Get(l)
+			if !ok {
+				return nil, nil, fmt.Errorf("failed to fetch secret: no secret returned for %s", l.Source)
 			}
 			slog.Info("Fetched secret", "source", l.Source)
 		}
@@ -221,180 +221,12 @@ func processSingleLease(cmd *cobra.Command, l lease.Lease, secretVal string, pro
 	return approvedLeases, approvedShellCommands, nil
 }
 
-// fetchSecretsParallel retrieves raw secret material for the provided leases using the
-// same parallelized batching strategy as the interactive flow. The returned map is keyed
-// by source URI. Any encountered errors are returned as grantError entries; when
-// continueOnError is false, the first failure terminates early.
-func fetchSecretsParallel(leases []lease.Lease, continueOnError bool, mode string) (map[string]string, []grantError, error) {
-	type accountGroup struct {
-		account string
-		leases  []lease.Lease
+func lookupGrantErrors(lookupErrs []secretlookup.Error) []grantError {
+	errs := make([]grantError, 0, len(lookupErrs))
+	for _, lookupErr := range lookupErrs {
+		errs = append(errs, grantError{Source: lookupErr.Lease.Source, Err: lookupErr.Err})
 	}
-
-	opBatches := map[string]*accountGroup{}
-	fileURIs := map[string]struct{}{}
-	var directFetchLeases []lease.Lease
-
-	for _, l := range leases {
-		if strings.HasPrefix(l.Source, "op://") {
-			actualAcct := l.OpAccount
-			key := actualAcct
-			if key == "" {
-				key = "default"
-			}
-			group := opBatches[key]
-			if group == nil {
-				group = &accountGroup{account: actualAcct}
-				opBatches[key] = group
-			}
-			group.leases = append(group.leases, l)
-			continue
-		}
-		if strings.HasPrefix(l.Source, "op+file://") {
-			fileURIs[l.Source] = struct{}{}
-			continue
-		}
-		directFetchLeases = append(directFetchLeases, l)
-	}
-
-	slog.Debug("grant fetch: phase 2 start",
-		"mode", mode,
-		"lease_count", len(leases),
-		"op_batches", len(opBatches),
-		"file_sources", len(fileURIs),
-		"direct_sources", len(directFetchLeases))
-
-	fetched := make(map[string]string, len(leases))
-	var errs []grantError
-
-	var fetchMu sync.Mutex
-	var fetchGroup errgroup.Group
-
-	for key, batch := range opBatches {
-		batchKey := key
-		b := batch
-		sources := make([]string, 0, len(b.leases))
-		for _, lease := range b.leases {
-			sources = append(sources, lease.Source)
-		}
-
-		fetchGroup.Go(func() error {
-			var p provider.SecretProvider
-			if os.Getenv("ENV_LEASE_TEST") == "1" {
-				p = &provider.MockProvider{}
-			} else {
-				p = &provider.OnePasswordCLI{Account: b.account}
-			}
-
-			secrets, perrs := p.FetchLeases(b.leases)
-
-			localErrs := make([]grantError, 0, len(perrs))
-			for _, pe := range perrs {
-				localErrs = append(localErrs, grantError{Source: pe.Lease.Source, Err: pe.Err})
-			}
-
-			fetchMu.Lock()
-			for src, val := range secrets {
-				fetched[src] = val
-			}
-			if len(localErrs) > 0 {
-				errs = append(errs, localErrs...)
-			}
-			fetchMu.Unlock()
-
-			slog.Debug("grant fetch: fetched op batch",
-				"mode", mode,
-				"group_key", batchKey,
-				"account", b.account,
-				"count", len(sources),
-				"success_count", len(secrets),
-				"error_count", len(perrs))
-
-			if len(localErrs) > 0 && !continueOnError {
-				return fmt.Errorf("grant fetch: failed op batch %s", batchKey)
-			}
-			return nil
-		})
-	}
-
-	for src := range fileURIs {
-		source := src
-
-		fetchGroup.Go(func() error {
-			var p provider.SecretProvider
-			lAccount := ""
-			for _, l := range leases {
-				if l.Source == source {
-					lAccount = l.OpAccount
-					break
-				}
-			}
-			if os.Getenv("ENV_LEASE_TEST") == "1" {
-				p = &provider.MockProvider{}
-			} else {
-				p = &provider.OnePasswordCLI{Account: lAccount}
-			}
-
-			val, err := p.Fetch(source)
-			if err != nil {
-				fetchMu.Lock()
-				errs = append(errs, grantError{Source: source, Err: err})
-				fetchMu.Unlock()
-				if !continueOnError {
-					return fmt.Errorf("grant fetch: failed file source %s", source)
-				}
-				return nil
-			}
-
-			fetchMu.Lock()
-			fetched[source] = val
-			fetchMu.Unlock()
-
-			slog.Debug("grant fetch: fetched file source",
-				"mode", mode,
-				"source", source)
-			return nil
-		})
-	}
-
-	for _, l := range directFetchLeases {
-		lease := l
-
-		fetchGroup.Go(func() error {
-			var p provider.SecretProvider
-			if os.Getenv("ENV_LEASE_TEST") == "1" {
-				p = &provider.MockProvider{}
-			} else {
-				p = &provider.OnePasswordCLI{Account: lease.OpAccount}
-			}
-
-			val, err := p.Fetch(lease.Source)
-			if err != nil {
-				fetchMu.Lock()
-				errs = append(errs, grantError{Source: lease.Source, Err: err})
-				fetchMu.Unlock()
-				if !continueOnError {
-					return fmt.Errorf("grant fetch: failed direct source %s", lease.Source)
-				}
-				return nil
-			}
-
-			fetchMu.Lock()
-			fetched[lease.Source] = val
-			fetchMu.Unlock()
-
-			slog.Debug("grant fetch: fetched direct source",
-				"mode", mode,
-				"source", lease.Source)
-			return nil
-		})
-	}
-
-	waitErr := fetchGroup.Wait()
-	if waitErr != nil && !continueOnError {
-		return fetched, errs, waitErr
-	}
-	return fetched, errs, nil
+	return errs
 }
 
 var grantCmd = &cobra.Command{
@@ -462,14 +294,14 @@ This can be overridden with the --destination-outside-root flag.`,
 		var shellCommands []string
 		leases := make([]ipc.Lease, 0, len(leaseSet.Leases))
 
-		fetched, fetchErrs, fetchErr := fetchSecretsParallel(leaseSet.Leases, continueOnError, "non-interactive")
-		errs = append(errs, fetchErrs...)
+		fetched, fetchErrs, fetchErr := secretlookup.Fetch(leaseSet.Leases, secretlookup.Options{ContinueOnError: continueOnError, Mode: "non-interactive"})
+		errs = append(errs, lookupGrantErrors(fetchErrs)...)
 		if fetchErr != nil {
 			return &GrantErrors{errs: errs}
 		}
 
 		for _, l := range leaseSet.Leases {
-			secretVal, ok := fetched[l.Source]
+			secretVal, ok := fetched.Get(l)
 			if !ok {
 				// Missing secret indicates a prior fetch failure.
 				if !continueOnError {
@@ -709,19 +541,23 @@ func interactiveGrant(cmd *cobra.Command, leaseSet *lease.Set, client *ipc.Clien
 
 	var errs []grantError
 
-	fetched, fetchErrs, fetchErr := fetchSecretsParallel(selectedLeases, continueOnError, "interactive")
-	errs = append(errs, fetchErrs...)
+	fetched, fetchErrs, fetchErr := secretlookup.Fetch(selectedLeases, secretlookup.Options{ContinueOnError: continueOnError, Mode: "interactive"})
+	errs = append(errs, lookupGrantErrors(fetchErrs)...)
 	if fetchErr != nil {
 		return &GrantErrors{errs: errs}
 	}
 
-	// Pre-compute explode expansions without writing or prompting
+	// Pre-compute transform results without writing or prompting.
 	type child struct {
 		lease lease.Lease
 		value string
 	}
+	type simple struct {
+		lease lease.Lease
+		value string
+	}
 	explodedChildren := make([]child, 0)
-	simpleApproved := make([]lease.Lease, 0)
+	simpleApproved := make([]simple, 0)
 	parentApproved := make([]ipc.Lease, 0)
 
 	slog.Debug("interactive grant: preprocessing transforms",
@@ -729,18 +565,26 @@ func interactiveGrant(cmd *cobra.Command, leaseSet *lease.Set, client *ipc.Clien
 
 	for _, l := range selectedLeases {
 		isExplode := l.IsExplode()
-		raw := fetched[l.Source]
+		raw, ok := fetched.Get(l)
+		if !ok {
+			errs = append(errs, grantError{Source: l.Source, Err: fmt.Errorf("no secret returned")})
+			if !continueOnError {
+				return &GrantErrors{errs: errs}
+			}
+			continue
+		}
+
 		formatted := l
 		slog.Debug("interactive grant: preparing lease",
 			"source", formatted.Source,
 			"explode", isExplode,
 			"transform_steps", len(formatted.Transform))
-		if !isExplode {
+		if len(formatted.Transform) == 0 {
 			// simple lease; Phase 1 already approved — no more prompts later
-			simpleApproved = append(simpleApproved, formatted)
+			simpleApproved = append(simpleApproved, simple{lease: formatted, value: raw})
 			continue
 		}
-		// explode: run pipeline on the fetched raw
+
 		pipe, err := transform.NewPipeline(formatted.Transform)
 		if err != nil {
 			errs = append(errs, grantError{Source: formatted.Source, Err: err})
@@ -800,8 +644,12 @@ func interactiveGrant(cmd *cobra.Command, leaseSet *lease.Set, client *ipc.Clien
 			// pipeline resulted in single value — treat as simple
 			slog.Debug("interactive grant: pipeline produced single value", "source", formatted.Source)
 			formatted.Variable = strings.TrimSpace(formatted.Variable)
-			fetched[formatted.Source] = s
-			simpleApproved = append(simpleApproved, formatted)
+			simpleApproved = append(simpleApproved, simple{lease: formatted, value: s})
+		} else {
+			errs = append(errs, grantError{Source: formatted.Source, Err: fmt.Errorf("transform pipeline must produce a string or exploded data")})
+			if !continueOnError {
+				return &GrantErrors{errs: errs}
+			}
 		}
 	}
 
@@ -815,9 +663,9 @@ func interactiveGrant(cmd *cobra.Command, leaseSet *lease.Set, client *ipc.Clien
 	finalLeases = append(finalLeases, parentApproved...)
 
 	// First, materialize all simple leases (no new prompts)
-	for _, l := range simpleApproved {
-		val := fetched[l.Source]
-		leas, sc, err := processLease(cmd, l, val, leaseSet.Root, leaseSet.ConfigFile)
+	for _, approved := range simpleApproved {
+		l := approved.lease
+		leas, sc, err := processLease(cmd, l, approved.value, leaseSet.Root, leaseSet.ConfigFile)
 		if err != nil {
 			errs = append(errs, grantError{Source: l.Source, Err: err})
 			if !continueOnError {

--- a/internal/provider/onepassword.go
+++ b/internal/provider/onepassword.go
@@ -185,102 +185,72 @@ func (p *OnePasswordCLI) fetchWithRead(sourceURI string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// FetchLeases fetches secrets for a slice of leases, using `op inject` for op://
-// URIs and falling back to individual `op read` calls for op+file:// URIs.
+// FetchLeases fetches secrets for this adapter's configured account. Callers
+// are responsible for grouping Leases by account before crossing this seam.
 func (p *OnePasswordCLI) FetchLeases(leases []lease.Lease) (map[string]string, []ProviderError) {
 	secrets := make(map[string]string, len(leases))
 	var perrs []ProviderError
 
-	// Partition by scheme
-	type leaseBatch map[string][]lease.Lease // sanitized source -> leases sharing it
-	type accountBatch struct {
-		account string
-		leases  leaseBatch
-	}
-	opAccounts := map[string]*accountBatch{} // grouping key -> batch
-
-	var singletons []lease.Lease // op+file and anything non-batchable
+	leasesBySource := make(map[string][]lease.Lease)
+	var singletons []lease.Lease
 
 	for _, l := range leases {
 		src := sanitizeOpURI(l.Source)
 		if strings.HasPrefix(src, "op://") {
-			actualAcct := l.OpAccount
-			if actualAcct == "" {
-				actualAcct = p.Account
-			}
-			key := actualAcct
-			if key == "" {
-				key = "default"
-			}
-
-			group := opAccounts[key]
-			if group == nil {
-				group = &accountBatch{
-					account: actualAcct,
-					leases:  make(leaseBatch),
-				}
-				opAccounts[key] = group
-			}
-			group.leases[src] = append(group.leases[src], l)
+			leasesBySource[src] = append(leasesBySource[src], l)
 			slog.Debug("onepassword: queued op lease",
-				"account_group", key,
-				"account", actualAcct,
+				"account", p.Account,
 				"source", l.Source,
 				"sanitized", src)
 			continue
 		}
-		// op+file:// and others are fetched one-by-one (grant-side also caches)
+
+		// This fallback keeps the adapter safe for direct callers; higher-level
+		// lookup orchestration normally fetches non-batchable sources itself.
 		singletons = append(singletons, l)
 		slog.Debug("onepassword: queued singleton lease",
+			"account", p.Account,
 			"source", l.Source,
 			"sanitized", src)
 	}
 
-	// Batch op:// by account
-	for key, batch := range opAccounts {
-		sub := &OnePasswordCLI{Account: batch.account}
-		request := make(map[string]string, len(batch.leases))
-		for sanitized := range batch.leases {
+	if len(leasesBySource) > 0 {
+		request := make(map[string]string, len(leasesBySource))
+		for sanitized := range leasesBySource {
 			request[sanitized] = sanitized
 		}
 
 		slog.Debug("onepassword: fetch bulk start",
-			"account_group", key,
-			"account", batch.account,
+			"account", p.Account,
 			"request_count", len(request))
 
-		res, err := sub.FetchBulk(request)
+		res, err := p.FetchBulk(request)
 		if err != nil {
-			// attribute an error to each lease in this batch
-			for _, leases := range batch.leases {
+			for _, leases := range leasesBySource {
 				for _, l := range leases {
 					perrs = append(perrs, ProviderError{Lease: l, Err: err})
 				}
 			}
 			slog.Debug("onepassword: fetch bulk error",
-				"account_group", key,
-				"account", batch.account,
+				"account", p.Account,
 				"err", err)
-			continue
-		}
-
-		for sanitized, leases := range batch.leases {
-			val, ok := res[sanitized]
-			if !ok {
-				continue
-			}
-			for _, l := range leases {
-				secrets[l.Source] = val
-				slog.Debug("onepassword: fetched lease",
-					"account_group", key,
-					"account", batch.account,
-					"source", l.Source,
-					"sanitized", sanitized)
+		} else {
+			for sanitized, leases := range leasesBySource {
+				val, ok := res[sanitized]
+				if !ok {
+					continue
+				}
+				for _, l := range leases {
+					secrets[l.Source] = val
+					slog.Debug("onepassword: fetched lease",
+						"account", p.Account,
+						"source", l.Source,
+						"sanitized", sanitized)
+				}
 			}
 		}
 	}
 
-	// Fetch singletons
 	for _, l := range singletons {
 		slog.Debug("onepassword: fetch singleton start", "source", l.Source)
 		val, err := p.Fetch(l.Source)

--- a/internal/provider/onepassword_test.go
+++ b/internal/provider/onepassword_test.go
@@ -22,58 +22,41 @@ func TestOnePasswordCLI_FetchLeases(t *testing.T) {
 	originalExecer := cmdExecer
 	defer func() { cmdExecer = originalExecer }()
 
-	t.Run("groups leases by account", func(t *testing.T) {
+	t.Run("fetches batch through configured account", func(t *testing.T) {
 		var capturedArgs [][]string
 		var mu sync.Mutex
 
-		var injectCall int
 		cmdExecer = &mockExecer{
 			CommandFunc: func(name string, arg ...string) *exec.Cmd {
 				mu.Lock()
 				capturedArgs = append(capturedArgs, arg)
 				mu.Unlock()
 
-				// Simulate the output of `op inject`
 				if len(arg) > 0 && arg[0] == "inject" {
-					injectCall++
-					if injectCall == 1 {
-						return exec.Command("echo", "-n", "lease_0=\"secret1\"")
-					}
-					return exec.Command("echo", "-n", "lease_0=\"secret2\"")
+					return exec.Command("echo", "-n", "lease_0=\"secret1\"\nlease_1=\"secret2\"")
 				}
 				return exec.Command("echo", "-n", "my-secret")
 			},
 		}
 
-		provider := &OnePasswordCLI{}
+		provider := &OnePasswordCLI{Account: "account1"}
 		leases := []lease.Lease{
 			{Variable: "VAR1", Source: "op://vault/item1", OpAccount: "account1"},
-			{Variable: "VAR2", Source: "op://vault/item2", OpAccount: "account2"},
+			{Variable: "VAR2", Source: "op://vault/item2", OpAccount: "account1"},
 		}
-		_, errs := provider.FetchLeases(leases)
+		secrets, errs := provider.FetchLeases(leases)
 		if len(errs) > 0 {
 			t.Fatalf("unexpected errors: %v", errs)
 		}
 
-		if len(capturedArgs) != 2 {
-			t.Fatalf("expected 2 calls to op, got %d", len(capturedArgs))
+		if len(capturedArgs) != 1 {
+			t.Fatalf("expected 1 call to op, got %d", len(capturedArgs))
 		}
-
-		var foundAccount1, foundAccount2 bool
-		for _, args := range capturedArgs {
-			if strings.Contains(strings.Join(args, " "), "--account account1") {
-				foundAccount1 = true
-			}
-			if strings.Contains(strings.Join(args, " "), "--account account2") {
-				foundAccount2 = true
-			}
+		if !strings.Contains(strings.Join(capturedArgs[0], " "), "--account account1") {
+			t.Fatalf("expected a call with --account account1, got %v", capturedArgs[0])
 		}
-
-		if !foundAccount1 {
-			t.Error("expected a call with --account account1")
-		}
-		if !foundAccount2 {
-			t.Error("expected a call with --account account2")
+		if len(secrets) != 2 || secrets["op://vault/item1"] == "" || secrets["op://vault/item2"] == "" {
+			t.Fatalf("unexpected secrets: %v", secrets)
 		}
 	})
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,13 +8,15 @@ type ProviderError struct {
 	Err   error
 }
 
-// SecretProvider defines the interface for fetching secrets from a backend.
+// SecretProvider defines the low-level adapter interface for fetching Secrets
+// from a Provider. Callers choose the concrete Provider/account adapter before
+// crossing this seam.
 type SecretProvider interface {
-	// Fetch retrieves a secret from the given source URI.
+	// Fetch retrieves a Secret from the given source URI.
 	Fetch(sourceURI string) (string, error)
-	// FetchLeases retrieves secrets for a slice of leases.
-	// RETURN CONTRACT: the returned map MUST be keyed by Lease.Source (the source URI).
-	// This ensures a stable key across simple, file, and explode flows.
+	// FetchLeases retrieves Secrets for a slice of Leases using this adapter's
+	// configured account. RETURN CONTRACT: the returned map MUST be keyed by
+	// Lease.Source (the source URI).
 	FetchLeases(leases []lease.Lease) (map[string]string, []ProviderError)
 }
 

--- a/internal/secretlookup/lookup.go
+++ b/internal/secretlookup/lookup.go
@@ -1,0 +1,299 @@
+// Package secretlookup owns Secret lookup orchestration for Grant flows.
+package secretlookup
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/mblarsen/env-lease/internal/lease"
+	"github.com/mblarsen/env-lease/internal/provider"
+	"golang.org/x/sync/errgroup"
+)
+
+// Error associates a Secret lookup failure with the Lease that needed it.
+type Error struct {
+	Lease lease.Lease
+	Err   error
+}
+
+// Options controls Secret lookup behaviour.
+type Options struct {
+	// ContinueOnError keeps resolving independent Leases after a lookup failure.
+	ContinueOnError bool
+	// Mode is included in diagnostic logs to identify the caller flow.
+	Mode string
+}
+
+// Secrets contains fetched Secret material keyed by the lookup facts for a Lease.
+type Secrets struct {
+	byKey map[key]string
+}
+
+// Get returns the fetched Secret material for l.
+func (s Secrets) Get(l lease.Lease) (string, bool) {
+	if s.byKey == nil {
+		return "", false
+	}
+	secret, ok := s.byKey[keyFor(l)]
+	return secret, ok
+}
+
+func (s *Secrets) set(l lease.Lease, secret string) {
+	if s.byKey == nil {
+		s.byKey = make(map[key]string)
+	}
+	s.byKey[keyFor(l)] = secret
+}
+
+// ProviderFactory creates Provider adapters for a normalized provider/account pair.
+type ProviderFactory func(providerName, account string) (provider.SecretProvider, error)
+
+// Lookup resolves Secret material for normalized Leases.
+type Lookup struct {
+	providerFactory ProviderFactory
+}
+
+// New creates a Secret lookup Module with the default Provider adapter factory.
+func New() *Lookup {
+	return NewWithProviderFactory(defaultProviderFactory)
+}
+
+// NewWithProviderFactory creates a Secret lookup Module with a custom Provider adapter factory.
+func NewWithProviderFactory(factory ProviderFactory) *Lookup {
+	if factory == nil {
+		factory = defaultProviderFactory
+	}
+	return &Lookup{providerFactory: factory}
+}
+
+// Fetch resolves Secret material for leases using the default lookup Module.
+func Fetch(leases []lease.Lease, opts Options) (Secrets, []Error, error) {
+	return New().Fetch(leases, opts)
+}
+
+// Fetch resolves Secret material for leases. op:// sources are batched by
+// Provider and account. Other sources are deduplicated by Provider, account, and
+// source URI, then fetched once and shared by matching Leases.
+func (lookup *Lookup) Fetch(leases []lease.Lease, opts Options) (Secrets, []Error, error) {
+	plan := buildPlan(leases)
+
+	slog.Debug("secret lookup: start",
+		"mode", opts.Mode,
+		"lease_count", len(leases),
+		"op_batches", len(plan.opBatches),
+		"single_sources", len(plan.singletons))
+
+	secrets := Secrets{byKey: make(map[key]string, len(leases))}
+	var errs []Error
+
+	var mu sync.Mutex
+	var group errgroup.Group
+
+	for _, batch := range plan.opBatches {
+		batch := batch
+		group.Go(func() error {
+			providerAdapter, err := lookup.providerFactory(batch.providerName, batch.account)
+			if err != nil {
+				lookupErrs := errorsForLeases(batch.leases, err)
+				mu.Lock()
+				errs = append(errs, lookupErrs...)
+				mu.Unlock()
+				if !opts.ContinueOnError {
+					return fmt.Errorf("secret lookup: provider %s account %s: %w", batch.providerName, batch.account, err)
+				}
+				return nil
+			}
+
+			fetched, providerErrs := providerAdapter.FetchLeases(batch.leases)
+			lookupErrs := lookupErrors(providerErrs)
+
+			if len(providerErrs) == 0 {
+				for _, leaseToFill := range batch.leases {
+					if _, ok := fetched[leaseToFill.Source]; !ok {
+						lookupErrs = append(lookupErrs, Error{
+							Lease: leaseToFill,
+							Err:   fmt.Errorf("no secret returned for %s", leaseToFill.Source),
+						})
+					}
+				}
+			}
+
+			mu.Lock()
+			for _, leaseToFill := range batch.leases {
+				if secret, ok := fetched[leaseToFill.Source]; ok {
+					secrets.set(leaseToFill, secret)
+				}
+			}
+			if len(lookupErrs) > 0 {
+				errs = append(errs, lookupErrs...)
+			}
+			mu.Unlock()
+
+			slog.Debug("secret lookup: fetched op batch",
+				"mode", opts.Mode,
+				"provider", batch.providerName,
+				"account", batch.account,
+				"count", len(batch.leases),
+				"success_count", len(fetched),
+				"error_count", len(providerErrs))
+
+			if len(lookupErrs) > 0 && !opts.ContinueOnError {
+				return fmt.Errorf("secret lookup: failed op batch provider %s account %s", batch.providerName, batch.account)
+			}
+			return nil
+		})
+	}
+
+	for _, sourceGroup := range plan.singletons {
+		sourceGroup := sourceGroup
+		group.Go(func() error {
+			providerAdapter, err := lookup.providerFactory(sourceGroup.providerName, sourceGroup.account)
+			if err != nil {
+				lookupErrs := errorsForLeases(sourceGroup.leases, err)
+				mu.Lock()
+				errs = append(errs, lookupErrs...)
+				mu.Unlock()
+				if !opts.ContinueOnError {
+					return fmt.Errorf("secret lookup: provider %s account %s: %w", sourceGroup.providerName, sourceGroup.account, err)
+				}
+				return nil
+			}
+
+			secret, err := providerAdapter.Fetch(sourceGroup.source)
+			if err != nil {
+				lookupErrs := errorsForLeases(sourceGroup.leases, err)
+				mu.Lock()
+				errs = append(errs, lookupErrs...)
+				mu.Unlock()
+				if !opts.ContinueOnError {
+					return fmt.Errorf("secret lookup: failed source %s", sourceGroup.source)
+				}
+				return nil
+			}
+
+			mu.Lock()
+			for _, leaseToFill := range sourceGroup.leases {
+				secrets.set(leaseToFill, secret)
+			}
+			mu.Unlock()
+
+			slog.Debug("secret lookup: fetched source",
+				"mode", opts.Mode,
+				"provider", sourceGroup.providerName,
+				"account", sourceGroup.account,
+				"source", sourceGroup.source,
+				"lease_count", len(sourceGroup.leases))
+			return nil
+		})
+	}
+
+	waitErr := group.Wait()
+	if waitErr != nil && !opts.ContinueOnError {
+		return secrets, errs, waitErr
+	}
+	return secrets, errs, nil
+}
+
+func defaultProviderFactory(providerName, account string) (provider.SecretProvider, error) {
+	switch providerName {
+	case "", "1password":
+		if os.Getenv("ENV_LEASE_TEST") == "1" {
+			return &provider.MockProvider{}, nil
+		}
+		return &provider.OnePasswordCLI{Account: account}, nil
+	default:
+		return nil, fmt.Errorf("unknown provider %q", providerName)
+	}
+}
+
+type plan struct {
+	opBatches  []opBatch
+	singletons []sourceGroup
+}
+
+type opBatch struct {
+	providerName string
+	account      string
+	leases       []lease.Lease
+}
+
+type sourceGroup struct {
+	providerName string
+	account      string
+	source       string
+	leases       []lease.Lease
+}
+
+type providerAccount struct {
+	providerName string
+	account      string
+}
+
+type sourceKey struct {
+	providerName string
+	account      string
+	source       string
+}
+
+type key sourceKey
+
+func buildPlan(leases []lease.Lease) plan {
+	opByAccount := make(map[providerAccount]int)
+	singletonsBySource := make(map[sourceKey]int)
+	plan := plan{}
+
+	for _, l := range leases {
+		if strings.HasPrefix(l.Source, "op://") {
+			accountKey := providerAccount{providerName: l.Provider, account: l.OpAccount}
+			idx, ok := opByAccount[accountKey]
+			if !ok {
+				idx = len(plan.opBatches)
+				opByAccount[accountKey] = idx
+				plan.opBatches = append(plan.opBatches, opBatch{
+					providerName: l.Provider,
+					account:      l.OpAccount,
+				})
+			}
+			plan.opBatches[idx].leases = append(plan.opBatches[idx].leases, l)
+			continue
+		}
+
+		singletonKey := sourceKey{providerName: l.Provider, account: l.OpAccount, source: l.Source}
+		idx, ok := singletonsBySource[singletonKey]
+		if !ok {
+			idx = len(plan.singletons)
+			singletonsBySource[singletonKey] = idx
+			plan.singletons = append(plan.singletons, sourceGroup{
+				providerName: l.Provider,
+				account:      l.OpAccount,
+				source:       l.Source,
+			})
+		}
+		plan.singletons[idx].leases = append(plan.singletons[idx].leases, l)
+	}
+
+	return plan
+}
+
+func keyFor(l lease.Lease) key {
+	return key{providerName: l.Provider, account: l.OpAccount, source: l.Source}
+}
+
+func errorsForLeases(leases []lease.Lease, err error) []Error {
+	lookupErrs := make([]Error, 0, len(leases))
+	for _, l := range leases {
+		lookupErrs = append(lookupErrs, Error{Lease: l, Err: err})
+	}
+	return lookupErrs
+}
+
+func lookupErrors(providerErrs []provider.ProviderError) []Error {
+	lookupErrs := make([]Error, 0, len(providerErrs))
+	for _, providerErr := range providerErrs {
+		lookupErrs = append(lookupErrs, Error{Lease: providerErr.Lease, Err: providerErr.Err})
+	}
+	return lookupErrs
+}

--- a/internal/secretlookup/lookup_test.go
+++ b/internal/secretlookup/lookup_test.go
@@ -1,0 +1,197 @@
+package secretlookup
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/mblarsen/env-lease/internal/lease"
+	"github.com/mblarsen/env-lease/internal/provider"
+)
+
+type recordingProvider struct {
+	providerName string
+	account      string
+
+	mu                sync.Mutex
+	fetchLeasesCalls  [][]lease.Lease
+	fetchCalls        []string
+	fetchFailures     map[string]error
+	fetchLeaseFailure error
+}
+
+func (p *recordingProvider) Fetch(sourceURI string) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.fetchCalls = append(p.fetchCalls, sourceURI)
+	if err := p.fetchFailures[sourceURI]; err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("secret:%s:%s:%s", p.providerName, p.account, sourceURI), nil
+}
+
+func (p *recordingProvider) FetchLeases(leases []lease.Lease) (map[string]string, []provider.ProviderError) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.fetchLeasesCalls = append(p.fetchLeasesCalls, append([]lease.Lease(nil), leases...))
+	if p.fetchLeaseFailure != nil {
+		errs := make([]provider.ProviderError, 0, len(leases))
+		for _, l := range leases {
+			errs = append(errs, provider.ProviderError{Lease: l, Err: p.fetchLeaseFailure})
+		}
+		return nil, errs
+	}
+
+	secrets := make(map[string]string, len(leases))
+	for _, l := range leases {
+		secrets[l.Source] = fmt.Sprintf("secret:%s:%s:%s", p.providerName, p.account, l.Source)
+	}
+	return secrets, nil
+}
+
+type recordingFactory struct {
+	mu        sync.Mutex
+	providers map[string]*recordingProvider
+}
+
+func newRecordingFactory() *recordingFactory {
+	return &recordingFactory{providers: make(map[string]*recordingProvider)}
+}
+
+func (f *recordingFactory) factory(providerName, account string) (provider.SecretProvider, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	key := providerName + "/" + account
+	p := f.providers[key]
+	if p == nil {
+		p = &recordingProvider{
+			providerName:  providerName,
+			account:       account,
+			fetchFailures: map[string]error{},
+		}
+		f.providers[key] = p
+	}
+	return p, nil
+}
+
+func (f *recordingFactory) provider(providerName, account string) *recordingProvider {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.providers[providerName+"/"+account]
+}
+
+func TestLookupFetch_GroupsByProviderAccountAndDedupeSource(t *testing.T) {
+	factory := newRecordingFactory()
+	lookup := NewWithProviderFactory(factory.factory)
+
+	accountAShared := lease.Lease{Provider: "1password", Source: "op://vault/shared", OpAccount: "account-a", Variable: "A_SHARED"}
+	accountAOther := lease.Lease{Provider: "1password", Source: "op://vault/other", OpAccount: "account-a", Variable: "A_OTHER"}
+	accountBShared := lease.Lease{Provider: "1password", Source: "op://vault/shared", OpAccount: "account-b", Variable: "B_SHARED"}
+	fileOne := lease.Lease{Provider: "1password", Source: "op+file://item/file.json", OpAccount: "account-a", Variable: "FILE_ONE"}
+	fileTwo := lease.Lease{Provider: "1password", Source: "op+file://item/file.json", OpAccount: "account-a", Variable: "FILE_TWO"}
+
+	secrets, errs, err := lookup.Fetch([]lease.Lease{accountAShared, accountAOther, accountBShared, fileOne, fileTwo}, Options{})
+	if err != nil {
+		t.Fatalf("unexpected fetch error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected per-lease errors: %v", errs)
+	}
+
+	assertSecret := func(l lease.Lease, want string) {
+		t.Helper()
+		got, ok := secrets.Get(l)
+		if !ok {
+			t.Fatalf("missing secret for %#v", l)
+		}
+		if got != want {
+			t.Fatalf("secret mismatch for %s/%s: got %q want %q", l.OpAccount, l.Source, got, want)
+		}
+	}
+
+	assertSecret(accountAShared, "secret:1password:account-a:op://vault/shared")
+	assertSecret(accountAOther, "secret:1password:account-a:op://vault/other")
+	assertSecret(accountBShared, "secret:1password:account-b:op://vault/shared")
+	assertSecret(fileOne, "secret:1password:account-a:op+file://item/file.json")
+	assertSecret(fileTwo, "secret:1password:account-a:op+file://item/file.json")
+
+	accountAProvider := factory.provider("1password", "account-a")
+	if accountAProvider == nil {
+		t.Fatal("missing account-a provider")
+	}
+	if got := len(accountAProvider.fetchLeasesCalls); got != 1 {
+		t.Fatalf("account-a bulk calls = %d, want 1", got)
+	}
+	if got := len(accountAProvider.fetchLeasesCalls[0]); got != 2 {
+		t.Fatalf("account-a bulk lease count = %d, want 2", got)
+	}
+	if got := len(accountAProvider.fetchCalls); got != 1 {
+		t.Fatalf("account-a singleton fetch calls = %d, want 1", got)
+	}
+
+	accountBProvider := factory.provider("1password", "account-b")
+	if accountBProvider == nil {
+		t.Fatal("missing account-b provider")
+	}
+	if got := len(accountBProvider.fetchLeasesCalls); got != 1 {
+		t.Fatalf("account-b bulk calls = %d, want 1", got)
+	}
+	if got := len(accountBProvider.fetchCalls); got != 0 {
+		t.Fatalf("account-b singleton fetch calls = %d, want 0", got)
+	}
+}
+
+func TestLookupFetch_ContinueOnError(t *testing.T) {
+	factory := newRecordingFactory()
+	failingSource := "op+file://item/missing.json"
+
+	failingProvider := &recordingProvider{
+		providerName:  "1password",
+		account:       "account-a",
+		fetchFailures: map[string]error{failingSource: fmt.Errorf("missing file")},
+	}
+	factory.providers["1password/account-a"] = failingProvider
+
+	lookup := NewWithProviderFactory(factory.factory)
+	success := lease.Lease{Provider: "1password", Source: "op://vault/ok", OpAccount: "account-a", Variable: "OK"}
+	failure := lease.Lease{Provider: "1password", Source: failingSource, OpAccount: "account-a", Variable: "FAIL"}
+
+	secrets, errs, err := lookup.Fetch([]lease.Lease{success, failure}, Options{ContinueOnError: true})
+	if err != nil {
+		t.Fatalf("expected no top-level error with ContinueOnError, got %v", err)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("per-lease errors = %d, want 1", len(errs))
+	}
+	if errs[0].Lease.Source != failingSource {
+		t.Fatalf("error source = %q, want %q", errs[0].Lease.Source, failingSource)
+	}
+	if got, ok := secrets.Get(success); !ok || got != "secret:1password:account-a:op://vault/ok" {
+		t.Fatalf("successful secret = %q, %v", got, ok)
+	}
+}
+
+func TestLookupFetch_StopsOnError(t *testing.T) {
+	factory := newRecordingFactory()
+	failingSource := "op+file://item/missing.json"
+	failingProvider := &recordingProvider{
+		providerName:  "1password",
+		account:       "account-a",
+		fetchFailures: map[string]error{failingSource: fmt.Errorf("missing file")},
+	}
+	factory.providers["1password/account-a"] = failingProvider
+
+	lookup := NewWithProviderFactory(factory.factory)
+	failure := lease.Lease{Provider: "1password", Source: failingSource, OpAccount: "account-a", Variable: "FAIL"}
+
+	_, errs, err := lookup.Fetch([]lease.Lease{failure}, Options{})
+	if err == nil {
+		t.Fatal("expected top-level error")
+	}
+	if len(errs) != 1 {
+		t.Fatalf("per-lease errors = %d, want 1", len(errs))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/secretlookup` as the deep Module for Secret Lookup orchestration.
- Move Provider/account grouping, `op://` batching, singleton source deduping, parallel lookup, and per-Lease lookup errors out of `cmd/grant.go`.
- Narrow `internal/provider` to lower-level Provider adapters and update 1Password adapter tests.
- Document **Secret Lookup** in `CONTEXT.md`.

## Testing

- `mise run lint`
- `mise run test`
- `git diff --check`
