### PR TITLE
refactor: deepen daemon lease lifecycle

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,10 @@ _Avoid_: provider fetch, backend lookup, source read
 The background process that owns active Lease state and performs scheduled revocation.
 _Avoid_: worker, server, scheduler
 
+**Lease Lifecycle**:
+The state transitions that register, expire, retry, reconcile, and revoke active Leases inside the Daemon.
+_Avoid_: state handling, timer logic, daemon cleanup
+
 **Config**:
 The TOML declaration that describes desired Leases for a project.
 _Avoid_: manifest, spec, settings
@@ -47,12 +51,13 @@ _Avoid_: manifest, spec, settings
 - A **Provider** performs **Secret Lookup** for an approved **Lease**.
 - A **Grant** uses **Secret Lookup** before materializing a **Secret** at its **Destination**.
 - A **Grant** registers a **Lease** with the **Daemon**.
-- The **Daemon** performs **Revoke** when a **Lease** expires or is removed from **Config**.
+- The **Daemon** owns the **Lease Lifecycle** for active **Leases**.
+- The **Lease Lifecycle** performs **Revoke** when a **Lease** expires or is removed from **Config**.
 
 ## Example dialogue
 
 > **Dev:** "When I run **Grant**, does every **Secret** go through **Secret Lookup** immediately?"
-> **Domain expert:** "Only approved **Leases** should perform **Secret Lookup**, then the **Daemon** tracks when each **Lease** should **Revoke** its **Destination**."
+> **Domain expert:** "Only approved **Leases** should perform **Secret Lookup**, then the **Daemon** owns the **Lease Lifecycle** that decides when each **Lease** should **Revoke** its **Destination**."
 
 ## Flagged ambiguities
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -10,10 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/mblarsen/env-lease/internal/config"
-	"github.com/mblarsen/env-lease/internal/fileutil"
 	"github.com/mblarsen/env-lease/internal/ipc"
-	"github.com/mblarsen/env-lease/internal/lease"
 )
 
 // Clock is an interface for time-related functions to allow for mocking.
@@ -36,23 +32,20 @@ func (c *RealClock) Ticker(d time.Duration) *time.Ticker {
 // Daemon is the main daemon struct.
 type Daemon struct {
 	state     *State
-	statePath string
 	clock     Clock
 	ipcServer *ipc.Server
-	revoker   Revoker
-	notifier  Notifier
+	lifecycle *Lifecycle
 	mu        sync.Mutex
 }
 
 // NewDaemon creates a new daemon.
 func NewDaemon(state *State, statePath string, clock Clock, ipcServer *ipc.Server, revoker Revoker, notifier Notifier) *Daemon {
+	lifecycle := NewLifecycle(state, statePath, clock, revoker, notifier)
 	return &Daemon{
-		state:     normalizeState(state),
-		statePath: statePath,
+		state:     lifecycle.state,
 		clock:     clock,
 		ipcServer: ipcServer,
-		revoker:   revoker,
-		notifier:  notifier,
+		lifecycle: lifecycle,
 	}
 }
 
@@ -108,104 +101,27 @@ func (d *Daemon) Run(ctx context.Context) error {
 }
 
 func (d *Daemon) revokeOrphanedLeases() {
-	slog.Debug("Checking for orphaned leases from config changes...")
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	d.lifecycle.ReconcileConfigLeases()
+}
 
-	// Gather unique config files from the state
-	configFiles := make(map[string]struct{})
-	for _, lease := range d.state.Leases {
-		if lease.ConfigFile != "" {
-			configFiles[lease.ConfigFile] = struct{}{}
-		}
-	}
+func (d *Daemon) cleanupOrphanedLeases() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.lifecycle.MarkOrphanedLeases()
+}
 
-	stateChanged := false
-	for configFile := range configFiles {
-		// Load the current configuration from disk
-		resolvedConfigFile, err := config.ResolveConfigFile(configFile)
-		if err != nil {
-			slog.Warn("Could not resolve config file, skipping", "config", configFile, "err", err)
-			continue
-		}
-		cfg, err := config.Load(resolvedConfigFile, "")
-		if err != nil {
-			// If config can't be loaded (e.g., deleted), revoke all leases associated with it.
-			slog.Warn("Config file not found or failed to load; revoking associated leases", "config", configFile, "err", err)
-			for key, lease := range d.state.LeasesForConfigFile(configFile) {
-				if lease.LeaseType == "shell" {
-					slog.Debug("Ignoring shell lease type in orphaned lease check", "key", key)
-					delete(d.state.Leases, key)
-					stateChanged = true
-					continue
-				}
-				if err := d.revoker.Revoke(lease); err != nil {
-					slog.Error("Failed to revoke orphaned lease", "key", key, "err", err)
-				} else {
-					slog.Info("Revoked orphaned lease", "key", key)
-					delete(d.state.Leases, key)
-					stateChanged = true
-				}
-			}
-			continue
-		}
+func (d *Daemon) revokeExpiredLeases() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.lifecycle.RevokeExpired()
+}
 
-		// Create a map of leases defined in the config for efficient lookup.
-		// Lease identity must include source + destination + variable to avoid
-		// collisions when multiple leases share a source.
-		leaseSet, normalizeErrs := lease.NormalizePartial(cfg, configFile)
-		for _, err := range normalizeErrs {
-			slog.Warn("Skipping invalid config lease during orphan check", "config", configFile, "err", err)
-		}
-		configLeases := make(map[string]struct{}, len(leaseSet.Leases))
-		explodeParents := make(map[string]struct{})
-		for _, l := range leaseSet.Leases {
-			configLeases[l.Identity()] = struct{}{}
-			if l.IsExplode() {
-				// Explode leases create a parent entry with an empty variable and
-				// child entries that reference ParentSource at runtime.
-				parent := l
-				parent.Variable = ""
-				configLeases[parent.Identity()] = struct{}{}
-				explodeParents[parent.ParentIdentity()] = struct{}{}
-			}
-		}
-
-		// Check active leases against the config
-		for key, activeLease := range d.state.LeasesForConfigFile(configFile) {
-			activeIdentity := activeLease.Identity()
-			if _, exists := configLeases[activeIdentity]; exists {
-				continue
-			}
-			if activeLease.ParentSource != "" {
-				if _, exists := explodeParents[activeLease.ParentSource]; exists {
-					continue
-				}
-			}
-
-			slog.Info("Lease removed from config, revoking", "key", key)
-			if activeLease.LeaseType == "shell" {
-				slog.Debug("Ignoring shell lease type in orphaned lease check", "key", key)
-				delete(d.state.Leases, key)
-				stateChanged = true
-				continue
-			}
-			if err := d.revoker.Revoke(activeLease); err != nil {
-				slog.Error("Failed to revoke orphaned lease", "key", key, "err", err)
-				// Optionally, add to a retry queue here as well
-			} else {
-				delete(d.state.Leases, key)
-				stateChanged = true
-			}
-		}
-	}
-
-	if stateChanged {
-		if err := d.state.SaveState(d.statePath); err != nil {
-			slog.Error("Failed to save state after revoking orphaned leases", "err", err)
-		}
-	}
-	slog.Debug("Finished checking for orphaned leases.")
+func (d *Daemon) processRetryQueue() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.lifecycle.ProcessRetryQueue()
 }
 
 func (d *Daemon) Shutdown() error {
@@ -219,215 +135,8 @@ func (d *Daemon) Shutdown() error {
 	}
 
 	d.mu.Lock()
-
-	if d.statePath != "" {
-		if reloaded, err := LoadState(d.statePath); err != nil {
-			slog.Warn("Failed to reload state from disk during shutdown; continuing with in-memory state", "err", err)
-		} else {
-			d.state = reloaded
-		}
-	}
-	if d.state == nil {
-		d.state = NewState()
-	}
-
-	leasesToRevoke := make([]*lease.Lease, 0, len(d.state.Leases))
-	for key, lease := range d.state.Leases {
-		if lease == nil {
-			delete(d.state.Leases, key)
-			continue
-		}
-		leasesToRevoke = append(leasesToRevoke, lease)
-		delete(d.state.Leases, key)
-	}
-
-	retryItems := d.state.RetryQueue
-	d.state.RetryQueue = nil
-
+	err := d.lifecycle.Shutdown()
+	d.state = d.lifecycle.state
 	d.mu.Unlock()
-
-	for _, lease := range leasesToRevoke {
-		if lease.LeaseType == "shell" {
-			slog.Debug("Skipping shell lease during shutdown", "source", lease.Source)
-			continue
-		}
-		if err := d.revoker.Revoke(lease); err != nil {
-			slog.Error("Failed to revoke lease during shutdown", "source", lease.Source, "destination", lease.Destination, "err", err)
-		} else {
-			slog.Info("Revoked lease during shutdown", "source", lease.Source, "destination", lease.Destination)
-		}
-	}
-
-	for _, retry := range retryItems {
-		if retry.Lease == nil {
-			continue
-		}
-		if retry.Lease.LeaseType == "shell" {
-			slog.Debug("Skipping shell lease from retry queue during shutdown", "source", retry.Lease.Source)
-			continue
-		}
-		if err := d.revoker.Revoke(retry.Lease); err != nil {
-			slog.Error("Failed to revoke lease from retry queue during shutdown", "source", retry.Lease.Source, "destination", retry.Lease.Destination, "err", err)
-		} else {
-			slog.Info("Revoked lease from retry queue during shutdown", "source", retry.Lease.Source, "destination", retry.Lease.Destination)
-		}
-	}
-
-	d.mu.Lock()
-	d.state.Leases = make(map[string]*lease.Lease)
-	d.state.RetryQueue = nil
-	err := d.state.SaveState(d.statePath)
-	d.mu.Unlock()
-
-	if err != nil {
-		slog.Error("Failed to save cleared state during shutdown", "err", err)
-	} else {
-		if d.statePath != "" {
-			if removeErr := os.Remove(d.statePath); removeErr != nil && !os.IsNotExist(removeErr) {
-				slog.Warn("Failed to remove state file after saving empty state", "err", removeErr)
-			} else {
-				slog.Info("State cleared and state file removed; shutdown complete.")
-			}
-		} else {
-			slog.Info("State cleared; shutdown complete.")
-		}
-	}
-	return nil
-}
-
-func (d *Daemon) cleanupOrphanedLeases() {
-	slog.Debug("Starting orphaned lease cleanup...")
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	now := d.clock.Now()
-	stateChanged := false
-
-	for id, lease := range d.state.Leases {
-		// If a lease doesn't have a config file path, we can't check it.
-		if lease.ConfigFile == "" {
-			continue
-		}
-
-		// Check if the original config file still exists.
-		if _, err := os.Stat(lease.ConfigFile); os.IsNotExist(err) {
-			// The file is gone, so the lease is an orphan.
-			if lease.OrphanedSince == nil {
-				slog.Info("Marking lease as orphaned", "id", id, "config_file", lease.ConfigFile)
-				lease.OrphanedSince = &now
-				d.state.Leases[id] = lease
-				stateChanged = true
-			}
-		} else {
-			// The file exists, so if it was marked as orphaned, un-mark it.
-			if lease.OrphanedSince != nil {
-				slog.Info("Un-marking lease as orphaned", "id", id)
-				lease.OrphanedSince = nil
-				d.state.Leases[id] = lease
-				stateChanged = true
-			}
-		}
-
-		// Now, check if the lease has been orphaned for too long.
-		if lease.OrphanedSince != nil && now.Sub(*lease.OrphanedSince) > 30*24*time.Hour {
-			slog.Info("Purging lease orphaned for more than 30 days", "id", id)
-			// We can reuse the revokeOrphanedLeases logic, which already handles revocation.
-			// Here we just delete it from the state.
-			if err := d.revoker.Revoke(lease); err != nil {
-				slog.Error("Failed to revoke purged lease", "id", id, "err", err)
-			}
-			delete(d.state.Leases, id)
-			stateChanged = true
-		}
-	}
-
-	if stateChanged {
-		if err := d.state.SaveState(d.statePath); err != nil {
-			slog.Error("Failed to save state after cleaning up orphaned leases", "err", err)
-		}
-	}
-	slog.Debug("Finished cleaning up orphaned leases.")
-}
-
-func (d *Daemon) revokeExpiredLeases() {
-	slog.Debug("Checking for expired leases...")
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	now := d.clock.Now()
-	for id, lease := range d.state.Leases {
-		if now.After(lease.ExpiresAt) {
-			var err error
-			if lease.LeaseType != "shell" {
-				err = d.revoker.Revoke(lease)
-			}
-
-			if err != nil {
-				slog.Error("Failed to revoke lease, adding to retry queue", "id", id, "err", err)
-				d.state.RetryQueue = append(d.state.RetryQueue, RetryItem{
-					Lease:          lease,
-					Attempts:       1,
-					NextRetryTime:  now.Add(2 * time.Second),
-					InitialFailure: now,
-				})
-			} else {
-				slog.Info("Lease expired and was revoked", "id", id)
-				if d.notifier != nil {
-					title := "Lease Expired"
-					message := fmt.Sprintf("Lease for %s has expired and was revoked.", lease.Source)
-					if err := d.notifier.Notify(title, message); err != nil {
-						slog.Error("Failed to send notification", "err", err)
-					}
-				}
-			}
-			delete(d.state.Leases, id)
-			if err := d.state.SaveState(d.statePath); err != nil {
-				slog.Error("Failed to save state after lease expiration", "err", err)
-			}
-		}
-	}
-	slog.Debug("Finished checking for expired leases.")
-}
-
-func (d *Daemon) processRetryQueue() {
-	slog.Debug("Processing retry queue...")
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	now := d.clock.Now()
-	stateChanged := false
-	for i := len(d.state.RetryQueue) - 1; i >= 0; i-- {
-		item := d.state.RetryQueue[i]
-		if now.After(item.NextRetryTime) {
-			var err error
-			if item.Lease.LeaseType != "shell" {
-				err = d.revoker.Revoke(item.Lease)
-			}
-
-			if err != nil {
-				item.Attempts++
-				item.NextRetryTime = now.Add(time.Duration(item.Attempts*2) * time.Second) // Exponential backoff
-				d.state.RetryQueue[i] = item
-				stateChanged = true
-
-				// Create failure file if necessary
-				if now.Sub(item.InitialFailure) > 5*time.Minute {
-					failureFile := item.Lease.Destination + ".env-lease-REVOCATION-FAILURE"
-					content := fmt.Sprintf("Failed to revoke lease for %s at %s", item.Lease.Source, now.Format(time.RFC3339))
-					fileutil.AtomicWriteFile(failureFile, []byte(content), 0644)
-				}
-			} else {
-				// Success, remove from queue
-				d.state.RetryQueue = append(d.state.RetryQueue[:i], d.state.RetryQueue[i+1:]...)
-				stateChanged = true
-			}
-		}
-	}
-
-	if stateChanged {
-		if err := d.state.SaveState(d.statePath); err != nil {
-			slog.Error("Failed to save state after processing retry queue", "err", err)
-		}
-	}
-	slog.Debug("Finished processing retry queue.")
+	return err
 }

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/mblarsen/env-lease/internal/ipc"
-	"github.com/mblarsen/env-lease/internal/lease"
 )
 
 func (d *Daemon) handleIPC(payload []byte) ([]byte, error) {
@@ -32,6 +30,8 @@ func (d *Daemon) handleIPC(payload []byte) ([]byte, error) {
 		defer d.mu.Unlock()
 		return d.handleStatus(payload)
 	case "cleanup":
+		d.mu.Lock()
+		defer d.mu.Unlock()
 		return d.handleCleanup(payload)
 	default:
 		return nil, fmt.Errorf("unknown command: %s", req.Command)
@@ -41,9 +41,8 @@ func (d *Daemon) handleIPC(payload []byte) ([]byte, error) {
 func (d *Daemon) handleCleanup(payload []byte) ([]byte, error) {
 	slog.Debug("Received cleanup request")
 
-	// Run the cleanup logic immediately
-	d.cleanupOrphanedLeases()
-	d.revokeOrphanedLeases()
+	d.lifecycle.MarkOrphanedLeases()
+	d.lifecycle.ReconcileConfigLeases()
 
 	resp := ipc.CleanupResponse{Messages: []string{"Orphaned lease cleanup process completed."}}
 	slog.Info("Orphaned lease cleanup process completed.")
@@ -57,57 +56,12 @@ func (d *Daemon) handleGrant(payload []byte) ([]byte, error) {
 	}
 	slog.Debug("Received grant request", "leases", len(req.Leases))
 
-	if !req.Append {
-		// Revoke any leases that are in the state but not in the request.
-		activeLeases := d.state.LeasesForConfigFile(req.ConfigFile)
-		for key, activeLease := range activeLeases {
-			found := false
-			for _, reqLease := range req.Leases {
-				if activeLease.Source == reqLease.Source && activeLease.Destination == reqLease.Destination && activeLease.Variable == reqLease.Variable {
-					found = true
-					break
-				}
-			}
-			if !found {
-				slog.Info("Revoking lease removed from config", "key", key)
-				if err := d.revoker.Revoke(activeLease); err != nil {
-					slog.Error("Failed to revoke lease removed from config", "key", key, "err", err)
-					// Continue trying to revoke other leases
-				}
-				delete(d.state.Leases, key)
-			}
-		}
-	} else {
-		slog.Debug("Grant request in append mode; skipping reconciliation revokes", "config_file", req.ConfigFile)
-	}
-
-	for _, l := range req.Leases {
-		duration, err := time.ParseDuration(l.Duration)
-		if err != nil {
-			return nil, fmt.Errorf("invalid duration '%s': %w", l.Duration, err)
-		}
-
-		runtimeLease := lease.FromIPC(l)
-		runtimeLease.ExpiresAt = d.clock.Now().Add(duration)
-		runtimeLease.OrphanedSince = nil
-		runtimeLease.ConfigFile = req.ConfigFile
-		key := runtimeLease.Identity()
-		d.state.Leases[key] = &runtimeLease
-		slog.Debug("Adding lease to state", "source", runtimeLease.Source, "expires_at", runtimeLease.ExpiresAt)
-	}
-
-	if err := d.state.SaveState(d.statePath); err != nil {
-		slog.Error("Failed to save state after grant", "err", err)
-		// Do not return error to client, as the grant itself succeeded
+	actualLeaseCount, err := d.lifecycle.Grant(req)
+	if err != nil {
+		return nil, err
 	}
 
 	resp := ipc.GrantResponse{Messages: []string{}}
-	actualLeaseCount := 0
-	for _, l := range req.Leases {
-		if l.LeaseType == "file" || l.Variable != "" {
-			actualLeaseCount++
-		}
-	}
 	slog.Info("Granted leases", "count", actualLeaseCount)
 	return json.Marshal(resp)
 }
@@ -119,70 +73,15 @@ func (d *Daemon) handleRevoke(payload []byte) ([]byte, error) {
 	}
 	slog.Debug("Received revoke request", "config_file", req.ConfigFile, "all", req.All)
 
-	var count int
-	var shellCommands []string
-
-	if len(req.Leases) > 0 {
-		for _, l := range req.Leases {
-			id := lease.FromIPC(l).Identity()
-			if lease, ok := d.state.Leases[id]; ok {
-				slog.Debug("Revoking lease", "source", lease.Source)
-				if lease.LeaseType == "shell" {
-					if lease.Variable != "" {
-						shellCommands = append(shellCommands, fmt.Sprintf("unset %s", lease.Variable))
-					}
-					slog.Debug("Ignoring revoker for shell lease type", "id", id)
-				} else {
-					if err := d.revoker.Revoke(lease); err != nil {
-						slog.Error("Failed to revoke lease", "id", id, "err", err)
-						// Continue trying to revoke other leases
-					}
-				}
-				delete(d.state.Leases, id)
-				if lease.LeaseType == "file" || lease.Variable != "" {
-					count++
-				}
-			}
-		}
-	} else {
-		for id, lease := range d.state.Leases {
-			if req.All || lease.ConfigFile == req.ConfigFile {
-				slog.Debug("Revoking lease", "source", lease.Source)
-				if lease.LeaseType == "shell" {
-					if lease.Variable != "" {
-						shellCommands = append(shellCommands, fmt.Sprintf("unset %s", lease.Variable))
-					}
-					slog.Debug("Ignoring revoker for shell lease type", "id", id)
-				} else {
-					if err := d.revoker.Revoke(lease); err != nil {
-						slog.Error("Failed to revoke lease", "id", id, "err", err)
-						// Continue trying to revoke other leases
-					}
-				}
-				delete(d.state.Leases, id)
-				if lease.LeaseType == "file" || lease.Variable != "" {
-					count++
-				}
-			}
-		}
+	result, err := d.lifecycle.Revoke(req)
+	if err != nil {
+		return nil, err
 	}
 
-	if err := d.state.SaveState(d.statePath); err != nil {
-		slog.Error("Failed to save state after revoke", "err", err)
-	}
-
-	if req.All && count > 0 {
-		title := "Leases Revoked"
-		message := fmt.Sprintf("Revoked %d leases due to system idle.", count)
-		if err := d.notifier.Notify(title, message); err != nil {
-			slog.Error("Failed to send notification", "err", err)
-		}
-	}
-
-	slog.Info("Revoked leases", "count", count, "all", req.All, "project", req.ConfigFile)
+	slog.Info("Revoked leases", "count", result.Count, "all", req.All, "project", req.ConfigFile)
 	resp := ipc.RevokeResponse{
-		Messages:      []string{fmt.Sprintf("Revoked %d leases.", count)},
-		ShellCommands: shellCommands,
+		Messages:      []string{fmt.Sprintf("Revoked %d leases.", result.Count)},
+		ShellCommands: result.ShellCommands,
 	}
 	return json.Marshal(resp)
 }
@@ -193,20 +92,6 @@ func (d *Daemon) handleStatus(payload []byte) ([]byte, error) {
 		return nil, fmt.Errorf("failed to unmarshal status request: %w", err)
 	}
 
-	var leases []ipc.Lease
-	for _, l := range d.state.Leases {
-		if req.ConfigFile == "" || l.ConfigFile == req.ConfigFile {
-			leases = append(leases, ipc.Lease{
-				Source:       l.Source,
-				Destination:  l.Destination,
-				LeaseType:    l.LeaseType,
-				Variable:     l.Variable,
-				ExpiresAt:    l.ExpiresAt,
-				ConfigFile:   l.ConfigFile,
-				ParentSource: l.ParentSource,
-			})
-		}
-	}
-	resp := ipc.StatusResponse{Leases: leases}
+	resp := ipc.StatusResponse{Leases: d.lifecycle.Status(req.ConfigFile)}
 	return json.Marshal(resp)
 }

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -1,0 +1,492 @@
+package daemon
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/mblarsen/env-lease/internal/config"
+	"github.com/mblarsen/env-lease/internal/fileutil"
+	"github.com/mblarsen/env-lease/internal/ipc"
+	"github.com/mblarsen/env-lease/internal/lease"
+)
+
+// Lifecycle owns active Lease state and all Daemon-side Lease lifecycle transitions.
+type Lifecycle struct {
+	state     *State
+	statePath string
+	clock     Clock
+	revoker   Revoker
+	notifier  Notifier
+}
+
+// RevokeResult describes the observable outcome of a Revoke lifecycle transition.
+type RevokeResult struct {
+	Count         int
+	ShellCommands []string
+}
+
+// NewLifecycle creates a lifecycle module over persistent daemon state.
+func NewLifecycle(state *State, statePath string, clock Clock, revoker Revoker, notifier Notifier) *Lifecycle {
+	return &Lifecycle{
+		state:     normalizeState(state),
+		statePath: statePath,
+		clock:     clock,
+		revoker:   revoker,
+		notifier:  notifier,
+	}
+}
+
+// Grant registers requested leases, reconciling removed leases unless append mode is enabled.
+func (l *Lifecycle) Grant(req ipc.GrantRequest) (int, error) {
+	if !req.Append {
+		l.reconcileGrantRequest(req)
+	} else {
+		slog.Debug("Grant request in append mode; skipping reconciliation revokes", "config_file", req.ConfigFile)
+	}
+
+	for _, ipcLease := range req.Leases {
+		duration, err := time.ParseDuration(ipcLease.Duration)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration '%s': %w", ipcLease.Duration, err)
+		}
+
+		runtimeLease := lease.FromIPC(ipcLease)
+		runtimeLease.ExpiresAt = l.clock.Now().Add(duration)
+		runtimeLease.OrphanedSince = nil
+		runtimeLease.ConfigFile = req.ConfigFile
+		key := runtimeLease.Identity()
+		l.state.Leases[key] = &runtimeLease
+		slog.Debug("Adding lease to state", "source", runtimeLease.Source, "expires_at", runtimeLease.ExpiresAt)
+	}
+
+	l.saveState("grant")
+	return actualIPCLeaseCount(req.Leases), nil
+}
+
+func (l *Lifecycle) reconcileGrantRequest(req ipc.GrantRequest) {
+	requested := make(map[string]struct{}, len(req.Leases))
+	for _, reqLease := range req.Leases {
+		requested[lease.FromIPC(reqLease).Identity()] = struct{}{}
+	}
+
+	for key, activeLease := range l.state.LeasesForConfigFile(req.ConfigFile) {
+		if _, found := requested[activeLease.Identity()]; found {
+			continue
+		}
+
+		slog.Info("Revoking lease removed from config", "key", key)
+		if err := l.revokeDestination(activeLease); err != nil {
+			slog.Error("Failed to revoke lease removed from config", "key", key, "err", err)
+		}
+		delete(l.state.Leases, key)
+	}
+}
+
+// Revoke revokes selected leases, all leases, or leases for one config file.
+func (l *Lifecycle) Revoke(req ipc.RevokeRequest) (RevokeResult, error) {
+	result := RevokeResult{}
+
+	if len(req.Leases) > 0 {
+		for _, ipcLease := range req.Leases {
+			id := lease.FromIPC(ipcLease).Identity()
+			activeLease, ok := l.state.Leases[id]
+			if !ok {
+				continue
+			}
+			l.revokeTrackedLease(id, activeLease, &result)
+		}
+	} else {
+		for id, activeLease := range l.state.Leases {
+			if req.All || activeLease.ConfigFile == req.ConfigFile {
+				l.revokeTrackedLease(id, activeLease, &result)
+			}
+		}
+	}
+
+	l.saveState("revoke")
+
+	if req.All && result.Count > 0 && l.notifier != nil {
+		title := "Leases Revoked"
+		message := fmt.Sprintf("Revoked %d leases due to system idle.", result.Count)
+		if err := l.notifier.Notify(title, message); err != nil {
+			slog.Error("Failed to send notification", "err", err)
+		}
+	}
+
+	return result, nil
+}
+
+func (l *Lifecycle) revokeTrackedLease(id string, activeLease *lease.Lease, result *RevokeResult) {
+	slog.Debug("Revoking lease", "source", activeLease.Source)
+	if activeLease.LeaseType == lease.TypeShell {
+		if activeLease.Variable != "" {
+			result.ShellCommands = append(result.ShellCommands, fmt.Sprintf("unset %s", activeLease.Variable))
+		}
+		slog.Debug("Ignoring revoker for shell lease type", "id", id)
+	} else if err := l.revokeDestination(activeLease); err != nil {
+		slog.Error("Failed to revoke lease", "id", id, "err", err)
+	}
+
+	delete(l.state.Leases, id)
+	if isActualLease(activeLease) {
+		result.Count++
+	}
+}
+
+// Status returns active leases, optionally filtered by config file.
+func (l *Lifecycle) Status(configFile string) []ipc.Lease {
+	leases := make([]ipc.Lease, 0, len(l.state.Leases))
+	for _, activeLease := range l.state.Leases {
+		if configFile == "" || activeLease.ConfigFile == configFile {
+			leases = append(leases, ipc.Lease{
+				Source:       activeLease.Source,
+				Destination:  activeLease.Destination,
+				LeaseType:    activeLease.LeaseType,
+				Variable:     activeLease.Variable,
+				ExpiresAt:    activeLease.ExpiresAt,
+				ConfigFile:   activeLease.ConfigFile,
+				ParentSource: activeLease.ParentSource,
+			})
+		}
+	}
+	return leases
+}
+
+// ReconcileConfigLeases revokes active leases that are no longer declared by their Config.
+func (l *Lifecycle) ReconcileConfigLeases() {
+	slog.Debug("Checking for orphaned leases from config changes...")
+
+	configFiles := make(map[string]struct{})
+	for _, activeLease := range l.state.Leases {
+		if activeLease.ConfigFile != "" {
+			configFiles[activeLease.ConfigFile] = struct{}{}
+		}
+	}
+
+	stateChanged := false
+	for configFile := range configFiles {
+		changed := l.reconcileConfigFile(configFile)
+		stateChanged = stateChanged || changed
+	}
+
+	if stateChanged {
+		l.saveState("revoking orphaned leases")
+	}
+	slog.Debug("Finished checking for orphaned leases.")
+}
+
+func (l *Lifecycle) reconcileConfigFile(configFile string) bool {
+	resolvedConfigFile, err := config.ResolveConfigFile(configFile)
+	if err != nil {
+		slog.Warn("Could not resolve config file, skipping", "config", configFile, "err", err)
+		return false
+	}
+
+	cfg, err := config.Load(resolvedConfigFile, "")
+	if err != nil {
+		slog.Warn("Config file not found or failed to load; revoking associated leases", "config", configFile, "err", err)
+		return l.revokeLeasesForMissingConfig(configFile)
+	}
+
+	configLeases, explodeParents := activeConfigIdentities(cfg, configFile)
+	stateChanged := false
+	for key, activeLease := range l.state.LeasesForConfigFile(configFile) {
+		if _, exists := configLeases[activeLease.Identity()]; exists {
+			continue
+		}
+		if activeLease.ParentSource != "" {
+			if _, exists := explodeParents[activeLease.ParentSource]; exists {
+				continue
+			}
+		}
+
+		slog.Info("Lease removed from config, revoking", "key", key)
+		if activeLease.LeaseType == lease.TypeShell {
+			slog.Debug("Ignoring shell lease type in orphaned lease check", "key", key)
+			delete(l.state.Leases, key)
+			stateChanged = true
+			continue
+		}
+		if err := l.revokeDestination(activeLease); err != nil {
+			slog.Error("Failed to revoke orphaned lease", "key", key, "err", err)
+			continue
+		}
+		delete(l.state.Leases, key)
+		stateChanged = true
+	}
+	return stateChanged
+}
+
+func (l *Lifecycle) revokeLeasesForMissingConfig(configFile string) bool {
+	stateChanged := false
+	for key, activeLease := range l.state.LeasesForConfigFile(configFile) {
+		if activeLease.LeaseType == lease.TypeShell {
+			slog.Debug("Ignoring shell lease type in orphaned lease check", "key", key)
+			delete(l.state.Leases, key)
+			stateChanged = true
+			continue
+		}
+		if err := l.revokeDestination(activeLease); err != nil {
+			slog.Error("Failed to revoke orphaned lease", "key", key, "err", err)
+			continue
+		}
+		slog.Info("Revoked orphaned lease", "key", key)
+		delete(l.state.Leases, key)
+		stateChanged = true
+	}
+	return stateChanged
+}
+
+func activeConfigIdentities(cfg *config.Config, configFile string) (map[string]struct{}, map[string]struct{}) {
+	leaseSet, normalizeErrs := lease.NormalizePartial(cfg, configFile)
+	for _, err := range normalizeErrs {
+		slog.Warn("Skipping invalid config lease during orphan check", "config", configFile, "err", err)
+	}
+
+	configLeases := make(map[string]struct{}, len(leaseSet.Leases))
+	explodeParents := make(map[string]struct{})
+	for _, normalizedLease := range leaseSet.Leases {
+		configLeases[normalizedLease.Identity()] = struct{}{}
+		if normalizedLease.IsExplode() {
+			parent := normalizedLease
+			parent.Variable = ""
+			configLeases[parent.Identity()] = struct{}{}
+			explodeParents[parent.ParentIdentity()] = struct{}{}
+		}
+	}
+	return configLeases, explodeParents
+}
+
+// MarkOrphanedLeases marks leases whose Config file is missing and purges long-orphaned leases.
+func (l *Lifecycle) MarkOrphanedLeases() {
+	slog.Debug("Starting orphaned lease cleanup...")
+
+	now := l.clock.Now()
+	stateChanged := false
+
+	for id, activeLease := range l.state.Leases {
+		if activeLease.ConfigFile == "" {
+			continue
+		}
+
+		if _, err := os.Stat(activeLease.ConfigFile); os.IsNotExist(err) {
+			if activeLease.OrphanedSince == nil {
+				slog.Info("Marking lease as orphaned", "id", id, "config_file", activeLease.ConfigFile)
+				activeLease.OrphanedSince = &now
+				l.state.Leases[id] = activeLease
+				stateChanged = true
+			}
+		} else if activeLease.OrphanedSince != nil {
+			slog.Info("Un-marking lease as orphaned", "id", id)
+			activeLease.OrphanedSince = nil
+			l.state.Leases[id] = activeLease
+			stateChanged = true
+		}
+
+		if activeLease.OrphanedSince != nil && now.Sub(*activeLease.OrphanedSince) > 30*24*time.Hour {
+			slog.Info("Purging lease orphaned for more than 30 days", "id", id)
+			if err := l.revokeDestination(activeLease); err != nil {
+				slog.Error("Failed to revoke purged lease", "id", id, "err", err)
+			}
+			delete(l.state.Leases, id)
+			stateChanged = true
+		}
+	}
+
+	if stateChanged {
+		l.saveState("cleaning up orphaned leases")
+	}
+	slog.Debug("Finished cleaning up orphaned leases.")
+}
+
+// RevokeExpired revokes expired active leases and queues failed revocations for retry.
+func (l *Lifecycle) RevokeExpired() {
+	slog.Debug("Checking for expired leases...")
+
+	now := l.clock.Now()
+	stateChanged := false
+	for id, activeLease := range l.state.Leases {
+		if !now.After(activeLease.ExpiresAt) {
+			continue
+		}
+
+		if err := l.revokeDestination(activeLease); err != nil {
+			slog.Error("Failed to revoke lease, adding to retry queue", "id", id, "err", err)
+			l.state.RetryQueue = append(l.state.RetryQueue, RetryItem{
+				Lease:          activeLease,
+				Attempts:       1,
+				NextRetryTime:  now.Add(2 * time.Second),
+				InitialFailure: now,
+			})
+		} else {
+			slog.Info("Lease expired and was revoked", "id", id)
+			l.notifyLeaseExpired(activeLease)
+		}
+		delete(l.state.Leases, id)
+		stateChanged = true
+	}
+
+	if stateChanged {
+		l.saveState("lease expiration")
+	}
+	slog.Debug("Finished checking for expired leases.")
+}
+
+func (l *Lifecycle) notifyLeaseExpired(activeLease *lease.Lease) {
+	if l.notifier == nil {
+		return
+	}
+	title := "Lease Expired"
+	message := fmt.Sprintf("Lease for %s has expired and was revoked.", activeLease.Source)
+	if err := l.notifier.Notify(title, message); err != nil {
+		slog.Error("Failed to send notification", "err", err)
+	}
+}
+
+// ProcessRetryQueue retries failed revocations and records persistent failure markers.
+func (l *Lifecycle) ProcessRetryQueue() {
+	slog.Debug("Processing retry queue...")
+
+	now := l.clock.Now()
+	stateChanged := false
+	for i := len(l.state.RetryQueue) - 1; i >= 0; i-- {
+		item := l.state.RetryQueue[i]
+		if !now.After(item.NextRetryTime) {
+			continue
+		}
+
+		if err := l.revokeDestination(item.Lease); err != nil {
+			item.Attempts++
+			item.NextRetryTime = now.Add(time.Duration(item.Attempts*2) * time.Second)
+			l.state.RetryQueue[i] = item
+			stateChanged = true
+			l.writeRevocationFailureFile(now, item)
+			continue
+		}
+
+		l.state.RetryQueue = append(l.state.RetryQueue[:i], l.state.RetryQueue[i+1:]...)
+		stateChanged = true
+	}
+
+	if stateChanged {
+		l.saveState("processing retry queue")
+	}
+	slog.Debug("Finished processing retry queue.")
+}
+
+func (l *Lifecycle) writeRevocationFailureFile(now time.Time, item RetryItem) {
+	if now.Sub(item.InitialFailure) <= 5*time.Minute {
+		return
+	}
+	failureFile := item.Lease.Destination + ".env-lease-REVOCATION-FAILURE"
+	content := fmt.Sprintf("Failed to revoke lease for %s at %s", item.Lease.Source, now.Format(time.RFC3339))
+	if _, err := fileutil.AtomicWriteFile(failureFile, []byte(content), 0644); err != nil {
+		slog.Error("Failed to write revocation failure file", "path", failureFile, "err", err)
+	}
+}
+
+// Shutdown revokes tracked leases, clears state, persists the empty state, and removes the state file.
+func (l *Lifecycle) Shutdown() error {
+	if l.statePath != "" {
+		if reloaded, err := LoadState(l.statePath); err != nil {
+			slog.Warn("Failed to reload state from disk during shutdown; continuing with in-memory state", "err", err)
+		} else {
+			l.state = reloaded
+		}
+	}
+	if l.state == nil {
+		l.state = NewState()
+	}
+
+	leasesToRevoke, retryItems := l.drainStateForShutdown()
+
+	for _, activeLease := range leasesToRevoke {
+		if activeLease.LeaseType == lease.TypeShell {
+			slog.Debug("Skipping shell lease during shutdown", "source", activeLease.Source)
+			continue
+		}
+		if err := l.revokeDestination(activeLease); err != nil {
+			slog.Error("Failed to revoke lease during shutdown", "source", activeLease.Source, "destination", activeLease.Destination, "err", err)
+		} else {
+			slog.Info("Revoked lease during shutdown", "source", activeLease.Source, "destination", activeLease.Destination)
+		}
+	}
+
+	for _, retry := range retryItems {
+		if retry.Lease == nil {
+			continue
+		}
+		if retry.Lease.LeaseType == lease.TypeShell {
+			slog.Debug("Skipping shell lease from retry queue during shutdown", "source", retry.Lease.Source)
+			continue
+		}
+		if err := l.revokeDestination(retry.Lease); err != nil {
+			slog.Error("Failed to revoke lease from retry queue during shutdown", "source", retry.Lease.Source, "destination", retry.Lease.Destination, "err", err)
+		} else {
+			slog.Info("Revoked lease from retry queue during shutdown", "source", retry.Lease.Source, "destination", retry.Lease.Destination)
+		}
+	}
+
+	l.state.Leases = make(map[string]*lease.Lease)
+	l.state.RetryQueue = nil
+	if err := l.state.SaveState(l.statePath); err != nil {
+		slog.Error("Failed to save cleared state during shutdown", "err", err)
+		return nil
+	}
+
+	if l.statePath != "" {
+		if removeErr := os.Remove(l.statePath); removeErr != nil && !os.IsNotExist(removeErr) {
+			slog.Warn("Failed to remove state file after saving empty state", "err", removeErr)
+		} else {
+			slog.Info("State cleared and state file removed; shutdown complete.")
+		}
+	} else {
+		slog.Info("State cleared; shutdown complete.")
+	}
+	return nil
+}
+
+func (l *Lifecycle) drainStateForShutdown() ([]*lease.Lease, []RetryItem) {
+	leasesToRevoke := make([]*lease.Lease, 0, len(l.state.Leases))
+	for key, activeLease := range l.state.Leases {
+		if activeLease == nil {
+			delete(l.state.Leases, key)
+			continue
+		}
+		leasesToRevoke = append(leasesToRevoke, activeLease)
+		delete(l.state.Leases, key)
+	}
+
+	retryItems := l.state.RetryQueue
+	l.state.RetryQueue = nil
+	return leasesToRevoke, retryItems
+}
+
+func (l *Lifecycle) revokeDestination(activeLease *lease.Lease) error {
+	if activeLease == nil || activeLease.LeaseType == lease.TypeShell {
+		return nil
+	}
+	return l.revoker.Revoke(activeLease)
+}
+
+func (l *Lifecycle) saveState(action string) {
+	if err := l.state.SaveState(l.statePath); err != nil {
+		slog.Error("Failed to save state after "+action, "err", err)
+	}
+}
+
+func actualIPCLeaseCount(leases []ipc.Lease) int {
+	count := 0
+	for _, ipcLease := range leases {
+		if ipcLease.LeaseType == lease.TypeFile || ipcLease.Variable != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func isActualLease(activeLease *lease.Lease) bool {
+	return activeLease.LeaseType == lease.TypeFile || activeLease.Variable != ""
+}

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mblarsen/env-lease/internal/ipc"
+	"github.com/mblarsen/env-lease/internal/lease"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLifecycleGrantReconcilesRemovedLeases(t *testing.T) {
+	state := NewState()
+	clock := &mockClock{now: time.Now()}
+	revoker := &mockRevoker{}
+	lifecycle := NewLifecycle(state, "/dev/null", clock, revoker, nil)
+
+	lease1 := ipc.Lease{
+		Source:      "1password",
+		Destination: "/tmp/foo",
+		LeaseType:   lease.TypeEnv,
+		Variable:    "MY_VAR_1",
+		Duration:    "1h",
+	}
+	lease2 := ipc.Lease{
+		Source:      "1password",
+		Destination: "/tmp/foo",
+		LeaseType:   lease.TypeEnv,
+		Variable:    "MY_VAR_2",
+		Duration:    "1h",
+	}
+
+	count, err := lifecycle.Grant(ipc.GrantRequest{
+		Leases:     []ipc.Lease{lease1, lease2},
+		ConfigFile: "/tmp/env-lease.toml",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	count, err = lifecycle.Grant(ipc.GrantRequest{
+		Leases:     []ipc.Lease{lease1},
+		ConfigFile: "/tmp/env-lease.toml",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	assert.Contains(t, state.Leases, "1password;/tmp/foo;MY_VAR_1")
+	assert.NotContains(t, state.Leases, "1password;/tmp/foo;MY_VAR_2")
+	require.Len(t, revoker.revoked, 1)
+	assert.Equal(t, "MY_VAR_2", revoker.revoked[0].Variable)
+}
+
+func TestLifecycleRevokeAllReturnsShellCommands(t *testing.T) {
+	state := NewState()
+	state.Leases["env"] = &lease.Lease{
+		Source:      "1password://vault/item/env",
+		Destination: "/tmp/env",
+		LeaseType:   lease.TypeEnv,
+		Variable:    "ENV_VAR",
+	}
+	state.Leases["shell"] = &lease.Lease{
+		Source:    "1password://vault/item/shell",
+		LeaseType: lease.TypeShell,
+		Variable:  "SHELL_VAR",
+	}
+
+	revoker := &mockRevoker{}
+	lifecycle := NewLifecycle(state, "/dev/null", &mockClock{now: time.Now()}, revoker, &mockNotifier{})
+
+	result, err := lifecycle.Revoke(ipc.RevokeRequest{All: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, result.Count)
+	assert.Equal(t, []string{"unset SHELL_VAR"}, result.ShellCommands)
+	assert.Equal(t, 1, revoker.RevokeCount)
+	assert.Empty(t, state.Leases)
+}


### PR DESCRIPTION
## Summary
- add an internal daemon `Lifecycle` module that owns Lease state transitions for grant, revoke, status, expiration, retry, orphan reconciliation, cleanup, and shutdown
- slim `Daemon` and IPC handlers down to locking, request decoding, run-loop ticking, and response formatting
- document the **Lease Lifecycle** domain term in `CONTEXT.md`
- add focused lifecycle tests for grant reconciliation and shell revoke output

## Testing
- `mise run lint`
- `mise run test`
- `git diff --check`
