### PR TITLE
refactor: deepen secret transformation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,10 @@ _Avoid_: backend, vault, service
 The act of resolving an approved Lease's Secret source through a Provider before Grant materializes it.
 _Avoid_: provider fetch, backend lookup, source read
 
+**Secret Transformation**:
+The act of converting fetched Secret material into the final Secret or set of Secrets that Grant can materialize.
+_Avoid_: post-processing, parsing, pipeline output
+
 **Daemon**:
 The background process that owns active Lease state and performs scheduled revocation.
 _Avoid_: worker, server, scheduler
@@ -49,7 +53,8 @@ _Avoid_: manifest, spec, settings
 - A **Config** declares zero or more **Leases**.
 - A **Lease** identifies exactly one **Secret** source and one **Destination**.
 - A **Provider** performs **Secret Lookup** for an approved **Lease**.
-- A **Grant** uses **Secret Lookup** before materializing a **Secret** at its **Destination**.
+- A **Grant** uses **Secret Lookup** before **Secret Transformation**.
+- **Secret Transformation** produces one **Secret** or an exploded set of Secrets for **Grant** to materialize at their **Destination**.
 - A **Grant** registers a **Lease** with the **Daemon**.
 - The **Daemon** owns the **Lease Lifecycle** for active **Leases**.
 - The **Lease Lifecycle** performs **Revoke** when a **Lease** expires or is removed from **Config**.
@@ -57,7 +62,7 @@ _Avoid_: manifest, spec, settings
 ## Example dialogue
 
 > **Dev:** "When I run **Grant**, does every **Secret** go through **Secret Lookup** immediately?"
-> **Domain expert:** "Only approved **Leases** should perform **Secret Lookup**, then the **Daemon** owns the **Lease Lifecycle** that decides when each **Lease** should **Revoke** its **Destination**."
+> **Domain expert:** "Only approved **Leases** should perform **Secret Lookup**; then **Secret Transformation** shapes the fetched material, and the **Daemon** owns the **Lease Lifecycle** that decides when each **Lease** should **Revoke** its **Destination**."
 
 ## Flagged ambiguities
 

--- a/cmd/grant.go
+++ b/cmd/grant.go
@@ -156,57 +156,24 @@ func processSingleLease(cmd *cobra.Command, l lease.Lease, secretVal string, pro
 			slog.Info("Fetched secret", "source", l.Source)
 		}
 
-		// Run transform pipeline
-		var transformResult interface{} = secretVal
-		if len(l.Transform) > 0 {
-
-			pipeline, err := transform.NewPipeline(l.Transform)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to create transform pipeline: %w", err)
-			}
-			transformResult, err = pipeline.Run(secretVal)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to transform secret: %w", err)
-			}
+		result, err := transform.Apply(l, secretVal)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to transform secret: %w", err)
 		}
 
-		switch result := transformResult.(type) {
-		case string:
-			// SINGLE LEASE CASE
-			finalLeases, sc, err := processLease(cmd, l, result, projectRoot, absConfigFile)
-			if err != nil {
-				return nil, nil, err
-			}
-			approvedLeases = append(approvedLeases, finalLeases...)
-			approvedShellCommands = append(approvedShellCommands, sc...)
-
-		case transform.ExplodedData:
-			// EXPLODED LEASE CASE
-			if l.LeaseType == "file" {
-				return nil, nil, fmt.Errorf("'explode' transform cannot be used with lease_type 'file'")
-			}
-
-			// Add a parent/container lease for the status command to find
-			parentLeaseConfig := l
-			parentLeaseConfig.Variable = "" // No single variable for the parent
-			parentLeases, _, err := processLease(cmd, parentLeaseConfig, "", projectRoot, absConfigFile)
+		if result.IsExploded() {
+			parentLeases, _, err := processLease(cmd, *result.Parent, "", projectRoot, absConfigFile)
 			if err != nil {
 				return nil, nil, err
 			}
 			approvedLeases = append(approvedLeases, parentLeases...)
-			uniqueParentID := parentLeaseConfig.ParentIdentity()
 
-			// Process all the child leases
 			fmt.Fprintf(os.Stderr, "Granting sub-leases from '%s'%s:\n", l.Source, getTransformSummary(l.Transform))
-			for key, value := range result {
-				if !interactive || confirm(fmt.Sprintf("Grant lease for '%s'?", key)) {
-					explodedLeaseConfig := l
-					explodedLeaseConfig.Variable = key
-					explodedLeaseConfig.ParentSource = uniqueParentID
-
-					finalLeases, sc, err := processLease(cmd, explodedLeaseConfig, value, projectRoot, absConfigFile)
+			for _, transformedSecret := range result.Secrets {
+				if !interactive || confirm(fmt.Sprintf("Grant lease for '%s'?", transformedSecret.Lease.Variable)) {
+					finalLeases, sc, err := processLease(cmd, transformedSecret.Lease, transformedSecret.Value, projectRoot, absConfigFile)
 					if err != nil {
-						*errs = append(*errs, grantError{Source: key, Err: err})
+						*errs = append(*errs, grantError{Source: transformedSecret.Lease.Variable, Err: err})
 						if !continueOnError {
 							return nil, nil, err
 						}
@@ -216,6 +183,16 @@ func processSingleLease(cmd *cobra.Command, l lease.Lease, secretVal string, pro
 					approvedShellCommands = append(approvedShellCommands, sc...)
 				}
 			}
+			return approvedLeases, approvedShellCommands, nil
+		}
+
+		for _, transformedSecret := range result.Secrets {
+			finalLeases, sc, err := processLease(cmd, transformedSecret.Lease, transformedSecret.Value, projectRoot, absConfigFile)
+			if err != nil {
+				return nil, nil, err
+			}
+			approvedLeases = append(approvedLeases, finalLeases...)
+			approvedShellCommands = append(approvedShellCommands, sc...)
 		}
 	}
 	return approvedLeases, approvedShellCommands, nil
@@ -380,7 +357,7 @@ This can be overridden with the --destination-outside-root flag.`,
 //
 // Parameters:
 //   - cmd: The cobra.Command object, used to access command-line flags.
-//   - l: The config.Lease object containing the lease details.
+//   - l: The normalized lease object containing the lease details.
 //   - secretVal: The secret value fetched from the provider.
 //   - projectRoot: The absolute path to the project root directory, which is the
 //     directory containing the configuration file. This is used to resolve
@@ -579,37 +556,22 @@ func interactiveGrant(cmd *cobra.Command, leaseSet *lease.Set, client *ipc.Clien
 			"source", formatted.Source,
 			"explode", isExplode,
 			"transform_steps", len(formatted.Transform))
-		if len(formatted.Transform) == 0 {
-			// simple lease; Phase 1 already approved — no more prompts later
-			simpleApproved = append(simpleApproved, simple{lease: formatted, value: raw})
+
+		result, err := transform.Apply(formatted, raw)
+		if err != nil {
+			errs = append(errs, grantError{Source: formatted.Source, Err: err})
+			if !continueOnError {
+				return &GrantErrors{errs: errs}
+			}
 			continue
 		}
 
-		pipe, err := transform.NewPipeline(formatted.Transform)
-		if err != nil {
-			errs = append(errs, grantError{Source: formatted.Source, Err: err})
-			if !continueOnError {
-				return &GrantErrors{errs: errs}
-			}
-			continue
-		}
-		res, err := pipe.Run(raw)
-		if err != nil {
-			errs = append(errs, grantError{Source: formatted.Source, Err: err})
-			if !continueOnError {
-				return &GrantErrors{errs: errs}
-			}
-			continue
-		}
-		if data, ok := res.(transform.ExplodedData); ok {
+		if result.IsExploded() {
 			slog.Debug("interactive grant: explode result",
 				"source", formatted.Source,
-				"child_count", len(data))
+				"child_count", len(result.Secrets))
 
-			parentLeaseConfig := formatted
-			parentLeaseConfig.Variable = ""
-
-			parentLeases, _, err := processLease(cmd, parentLeaseConfig, "", leaseSet.Root, leaseSet.ConfigFile)
+			parentLeases, _, err := processLease(cmd, *result.Parent, "", leaseSet.Root, leaseSet.ConfigFile)
 			if err != nil {
 				errs = append(errs, grantError{Source: formatted.Source, Err: err})
 				if !continueOnError {
@@ -625,31 +587,19 @@ func interactiveGrant(cmd *cobra.Command, leaseSet *lease.Set, client *ipc.Clien
 				continue
 			}
 
-			uniqueParentID := parentLeaseConfig.ParentIdentity()
-			for i := range parentLeases {
-				parentLeases[i].ParentSource = ""
-			}
 			parentApproved = append(parentApproved, parentLeases...)
-
-			for k, v := range data {
-				childLease := formatted
-				childLease.Variable = k
-				childLease.ParentSource = uniqueParentID
+			for _, transformedSecret := range result.Secrets {
 				explodedChildren = append(explodedChildren, child{
-					lease: childLease,
-					value: v,
+					lease: transformedSecret.Lease,
+					value: transformedSecret.Value,
 				})
 			}
-		} else if s, ok := res.(string); ok {
-			// pipeline resulted in single value — treat as simple
-			slog.Debug("interactive grant: pipeline produced single value", "source", formatted.Source)
-			formatted.Variable = strings.TrimSpace(formatted.Variable)
-			simpleApproved = append(simpleApproved, simple{lease: formatted, value: s})
-		} else {
-			errs = append(errs, grantError{Source: formatted.Source, Err: fmt.Errorf("transform pipeline must produce a string or exploded data")})
-			if !continueOnError {
-				return &GrantErrors{errs: errs}
-			}
+			continue
+		}
+
+		for _, transformedSecret := range result.Secrets {
+			slog.Debug("interactive grant: pipeline produced single value", "source", transformedSecret.Lease.Source)
+			simpleApproved = append(simpleApproved, simple{lease: transformedSecret.Lease, value: transformedSecret.Value})
 		}
 	}
 

--- a/internal/transform/apply.go
+++ b/internal/transform/apply.go
@@ -1,0 +1,76 @@
+package transform
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/mblarsen/env-lease/internal/lease"
+)
+
+// Secret is transformed Secret material attached to the Lease it should grant.
+type Secret struct {
+	Lease lease.Lease
+	Value string
+}
+
+// Result is the typed output of applying a transform pipeline to one Lease's raw Secret.
+type Result struct {
+	Parent  *lease.Lease
+	Secrets []Secret
+}
+
+// IsExploded reports whether the transform output expanded into child Leases.
+func (r Result) IsExploded() bool {
+	return r.Parent != nil
+}
+
+// Apply applies a Lease's transform pipeline to raw Secret material and returns
+// the resulting Grant-ready Secret material without materializing it.
+func Apply(l lease.Lease, rawSecret string) (Result, error) {
+	transformed := any(rawSecret)
+	if len(l.Transform) > 0 {
+		pipeline, err := NewPipeline(l.Transform)
+		if err != nil {
+			return Result{}, err
+		}
+		transformed, err = pipeline.Run(rawSecret)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+
+	switch result := transformed.(type) {
+	case string:
+		return Result{Secrets: []Secret{{Lease: l, Value: result}}}, nil
+	case ExplodedData:
+		if l.LeaseType == lease.TypeFile {
+			return Result{}, fmt.Errorf("'explode' transform cannot be used with lease_type 'file'")
+		}
+		return explodedResult(l, result), nil
+	default:
+		return Result{}, fmt.Errorf("transform pipeline must produce a string or exploded data")
+	}
+}
+
+func explodedResult(l lease.Lease, data ExplodedData) Result {
+	parent := l
+	parent.Variable = ""
+	parent.ParentSource = ""
+	parentID := parent.ParentIdentity()
+
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	secrets := make([]Secret, 0, len(keys))
+	for _, key := range keys {
+		child := l
+		child.Variable = key
+		child.ParentSource = parentID
+		secrets = append(secrets, Secret{Lease: child, Value: data[key]})
+	}
+
+	return Result{Parent: &parent, Secrets: secrets}
+}

--- a/internal/transform/apply_test.go
+++ b/internal/transform/apply_test.go
@@ -1,0 +1,85 @@
+package transform
+
+import (
+	"testing"
+
+	"github.com/mblarsen/env-lease/internal/lease"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApply(t *testing.T) {
+	t.Run("returns raw secret for lease without transforms", func(t *testing.T) {
+		l := lease.Lease{Source: "mock", Destination: ".env", LeaseType: lease.TypeEnv, Variable: "API_KEY"}
+
+		result, err := Apply(l, "secret")
+
+		require.NoError(t, err)
+		require.False(t, result.IsExploded())
+		require.Len(t, result.Secrets, 1)
+		assert.Equal(t, l, result.Secrets[0].Lease)
+		assert.Equal(t, "secret", result.Secrets[0].Value)
+	})
+
+	t.Run("returns transformed simple secret", func(t *testing.T) {
+		l := lease.Lease{
+			Source:      "mock",
+			Destination: ".env",
+			LeaseType:   lease.TypeEnv,
+			Variable:    "API_KEY",
+			Transform:   []string{"json", "select 'api.key'"},
+		}
+
+		result, err := Apply(l, `{"api":{"key":"selected-secret"}}`)
+
+		require.NoError(t, err)
+		require.False(t, result.IsExploded())
+		require.Len(t, result.Secrets, 1)
+		assert.Equal(t, l, result.Secrets[0].Lease)
+		assert.Equal(t, "selected-secret", result.Secrets[0].Value)
+	})
+
+	t.Run("returns parent and sorted exploded child secrets", func(t *testing.T) {
+		l := lease.Lease{
+			Source:      "mock-explode",
+			Destination: "/project/.env",
+			LeaseType:   lease.TypeEnv,
+			Transform:   []string{"json", "explode"},
+		}
+
+		result, err := Apply(l, `{"B_KEY":"b","A_KEY":"a"}`)
+
+		require.NoError(t, err)
+		require.True(t, result.IsExploded())
+		require.NotNil(t, result.Parent)
+		assert.Equal(t, "", result.Parent.Variable)
+		assert.Equal(t, "", result.Parent.ParentSource)
+		require.Len(t, result.Secrets, 2)
+
+		parentID := lease.ParentIdentity("mock-explode", "/project/.env")
+		assert.Equal(t, "A_KEY", result.Secrets[0].Lease.Variable)
+		assert.Equal(t, parentID, result.Secrets[0].Lease.ParentSource)
+		assert.Equal(t, "a", result.Secrets[0].Value)
+		assert.Equal(t, "B_KEY", result.Secrets[1].Lease.Variable)
+		assert.Equal(t, parentID, result.Secrets[1].Lease.ParentSource)
+		assert.Equal(t, "b", result.Secrets[1].Value)
+	})
+
+	t.Run("rejects explode for file leases", func(t *testing.T) {
+		l := lease.Lease{Source: "mock-explode", Destination: "/project/secret", LeaseType: lease.TypeFile, Transform: []string{"json", "explode"}}
+
+		_, err := Apply(l, `{"A_KEY":"a"}`)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'explode' transform cannot be used with lease_type 'file'")
+	})
+
+	t.Run("rejects non-terminal structured data", func(t *testing.T) {
+		l := lease.Lease{Source: "mock-json", Destination: "/project/.env", LeaseType: lease.TypeEnv, Variable: "JSON", Transform: []string{"json"}}
+
+		_, err := Apply(l, `{"A_KEY":"a"}`)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "transform pipeline must produce a string or exploded data")
+	})
+}


### PR DESCRIPTION
## Summary
- add a typed Secret Transformation interface with `transform.Apply`
- move explode parent/child Lease construction behind the transform module seam
- simplify Grant so it consumes typed transform results instead of inspecting `any` pipeline outputs
- document **Secret Transformation** in `CONTEXT.md`

## Testing
- `mise run lint`
- `mise run test`
- `git diff --check`
