### PR TITLE
refactor: deepen grant workflow

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,10 @@ _Avoid_: provider fetch, backend lookup, source read
 The act of converting fetched Secret material into the final Secret or set of Secrets that Grant can materialize.
 _Avoid_: post-processing, parsing, pipeline output
 
+**Grant Workflow**:
+The ordered decisions and steps that turn a desired Lease set into a Daemon registration request.
+_Avoid_: grant command logic, grant orchestration, CLI flow
+
 **Daemon**:
 The background process that owns active Lease state and performs scheduled revocation.
 _Avoid_: worker, server, scheduler
@@ -53,16 +57,17 @@ _Avoid_: manifest, spec, settings
 - A **Config** declares zero or more **Leases**.
 - A **Lease** identifies exactly one **Secret** source and one **Destination**.
 - A **Provider** performs **Secret Lookup** for an approved **Lease**.
-- A **Grant** uses **Secret Lookup** before **Secret Transformation**.
-- **Secret Transformation** produces one **Secret** or an exploded set of Secrets for **Grant** to materialize at their **Destination**.
-- A **Grant** registers a **Lease** with the **Daemon**.
+- A **Grant** runs a **Grant Workflow**.
+- The **Grant Workflow** uses **Secret Lookup** before **Secret Transformation**.
+- **Secret Transformation** produces one **Secret** or an exploded set of Secrets for the **Grant Workflow** to materialize at their **Destination**.
+- The **Grant Workflow** produces the request that registers **Leases** with the **Daemon**.
 - The **Daemon** owns the **Lease Lifecycle** for active **Leases**.
 - The **Lease Lifecycle** performs **Revoke** when a **Lease** expires or is removed from **Config**.
 
 ## Example dialogue
 
 > **Dev:** "When I run **Grant**, does every **Secret** go through **Secret Lookup** immediately?"
-> **Domain expert:** "Only approved **Leases** should perform **Secret Lookup**; then **Secret Transformation** shapes the fetched material, and the **Daemon** owns the **Lease Lifecycle** that decides when each **Lease** should **Revoke** its **Destination**."
+> **Domain expert:** "The **Grant Workflow** decides which **Leases** are approved first. Only approved **Leases** perform **Secret Lookup**; then **Secret Transformation** shapes the fetched material, and the **Daemon** owns the **Lease Lifecycle** that decides when each **Lease** should **Revoke** its **Destination**."
 
 ## Flagged ambiguities
 

--- a/cmd/grant.go
+++ b/cmd/grant.go
@@ -67,144 +67,18 @@ package cmd
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
-	"time"
 
 	"github.com/mblarsen/env-lease/internal/config"
 	"github.com/mblarsen/env-lease/internal/fileutil"
+	"github.com/mblarsen/env-lease/internal/grantflow"
 	"github.com/mblarsen/env-lease/internal/ipc"
 	"github.com/mblarsen/env-lease/internal/lease"
-	"github.com/mblarsen/env-lease/internal/secretlookup"
-	"github.com/mblarsen/env-lease/internal/transform"
 	"github.com/spf13/cobra"
 )
 
 var shellMode bool
-
-type grantError struct {
-	Source string
-	Err    error
-}
-
-type GrantErrors struct {
-	errs []grantError
-}
-
-func (e *GrantErrors) Error() string {
-	var sb strings.Builder
-	if len(e.errs) > 1 {
-		sb.WriteString(fmt.Sprintf("Failed to grant %d leases:\n\n", len(e.errs)))
-	} else {
-		sb.WriteString("Failed to grant lease:\n\n")
-	}
-	for _, ge := range e.errs {
-		sb.WriteString(fmt.Sprintf("Lease: %s\n", ge.Source))
-		sb.WriteString(fmt.Sprintf("└─ Error: %s\n\n", ge.Err))
-	}
-
-	if len(e.errs) > 1 {
-		sb.WriteString("Note: Other leases may have been granted successfully.\n")
-	}
-	return strings.TrimRight(sb.String(), "\n")
-}
-
-func processSingleLease(cmd *cobra.Command, l lease.Lease, secretVal string, projectRoot string, absConfigFile string, interactive bool, errs *[]grantError, continueOnError bool) ([]ipc.Lease, []string, error) {
-	// Duration validation
-	duration, err := time.ParseDuration(l.Duration)
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid duration '%s': %w", l.Duration, err)
-	}
-	if duration > 12*time.Hour {
-		slog.Warn("Leases longer than 12 hours are discouraged for security reasons.")
-	}
-
-	// Handle result: could be a single string or exploded data
-	var approvedLeases []ipc.Lease
-	var approvedShellCommands []string
-
-	// Pre-determine the prompt string
-	isExplode := l.IsExplode()
-
-	var prompt string
-	if isExplode {
-		prompt = fmt.Sprintf("Grant leases from '%s'?", l.Source)
-	} else if l.Variable == "" {
-		prompt = fmt.Sprintf("Grant lease for '%s'?", l.Source)
-	} else {
-		prompt = fmt.Sprintf("Grant lease for '%s'?", l.Variable)
-	}
-
-	if !interactive || (secretVal != "") || confirm(prompt) {
-		// Fetch secret if not already fetched
-		if secretVal == "" {
-			slog.Info("Fetching secret", "source", l.Source)
-			secrets, lookupErrs, err := secretlookup.Fetch([]lease.Lease{l}, secretlookup.Options{})
-			if len(lookupErrs) > 0 {
-				return nil, nil, fmt.Errorf("failed to fetch secret: %w", lookupErrs[0].Err)
-			}
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to fetch secret: %w", err)
-			}
-			var ok bool
-			secretVal, ok = secrets.Get(l)
-			if !ok {
-				return nil, nil, fmt.Errorf("failed to fetch secret: no secret returned for %s", l.Source)
-			}
-			slog.Info("Fetched secret", "source", l.Source)
-		}
-
-		result, err := transform.Apply(l, secretVal)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to transform secret: %w", err)
-		}
-
-		if result.IsExploded() {
-			parentLeases, _, err := processLease(cmd, *result.Parent, "", projectRoot, absConfigFile)
-			if err != nil {
-				return nil, nil, err
-			}
-			approvedLeases = append(approvedLeases, parentLeases...)
-
-			fmt.Fprintf(os.Stderr, "Granting sub-leases from '%s'%s:\n", l.Source, getTransformSummary(l.Transform))
-			for _, transformedSecret := range result.Secrets {
-				if !interactive || confirm(fmt.Sprintf("Grant lease for '%s'?", transformedSecret.Lease.Variable)) {
-					finalLeases, sc, err := processLease(cmd, transformedSecret.Lease, transformedSecret.Value, projectRoot, absConfigFile)
-					if err != nil {
-						*errs = append(*errs, grantError{Source: transformedSecret.Lease.Variable, Err: err})
-						if !continueOnError {
-							return nil, nil, err
-						}
-						continue
-					}
-					approvedLeases = append(approvedLeases, finalLeases...)
-					approvedShellCommands = append(approvedShellCommands, sc...)
-				}
-			}
-			return approvedLeases, approvedShellCommands, nil
-		}
-
-		for _, transformedSecret := range result.Secrets {
-			finalLeases, sc, err := processLease(cmd, transformedSecret.Lease, transformedSecret.Value, projectRoot, absConfigFile)
-			if err != nil {
-				return nil, nil, err
-			}
-			approvedLeases = append(approvedLeases, finalLeases...)
-			approvedShellCommands = append(approvedShellCommands, sc...)
-		}
-	}
-	return approvedLeases, approvedShellCommands, nil
-}
-
-func lookupGrantErrors(lookupErrs []secretlookup.Error) []grantError {
-	errs := make([]grantError, 0, len(lookupErrs))
-	for _, lookupErr := range lookupErrs {
-		errs = append(errs, grantError{Source: lookupErr.Lease.Source, Err: lookupErr.Err})
-	}
-	return errs
-}
 
 var grantCmd = &cobra.Command{
 	Use:   "grant",
@@ -262,66 +136,42 @@ This can be overridden with the --destination-outside-root flag.`,
 
 		client := ensureDaemonClient()
 
-		if interactive {
-			return interactiveGrant(cmd, leaseSet, client)
-		}
-
 		continueOnError, _ := cmd.Flags().GetBool("continue-on-error")
-		var errs []grantError
-		var shellCommands []string
-		leases := make([]ipc.Lease, 0, len(leaseSet.Leases))
-
-		fetched, fetchErrs, fetchErr := secretlookup.Fetch(leaseSet.Leases, secretlookup.Options{ContinueOnError: continueOnError, Mode: "non-interactive"})
-		errs = append(errs, lookupGrantErrors(fetchErrs)...)
-		if fetchErr != nil {
-			return &GrantErrors{errs: errs}
-		}
-
-		for _, l := range leaseSet.Leases {
-			secretVal, ok := fetched.Get(l)
-			if !ok {
-				// Missing secret indicates a prior fetch failure.
-				if !continueOnError {
-					return &GrantErrors{errs: errs}
-				}
-				continue
-			}
-			finalLeases, sc, err := processSingleLease(cmd, l, secretVal, leaseSet.Root, leaseSet.ConfigFile, false, &errs, continueOnError)
-			if err != nil {
-				errs = append(errs, grantError{Source: l.Source, Err: err})
-				if !continueOnError {
-					return &GrantErrors{errs: errs}
-				}
-				continue
-			}
-			leases = append(leases, finalLeases...)
-			shellCommands = append(shellCommands, sc...)
-		}
-
-		if len(errs) > 0 {
-			return &GrantErrors{errs: errs}
-		}
-
 		override, _ := cmd.Flags().GetBool("override")
-		req := ipc.GrantRequest{
-			Command:    "grant",
-			Leases:     leases,
-			Override:   override,
-			Append:     false,
-			ConfigFile: leaseSet.ConfigFile,
+		noDirenv, _ := cmd.Flags().GetBool("no-direnv")
+
+		flow := grantflow.Flow{
+			Confirm: confirm,
+			Notice: func(message string) {
+				fmt.Fprintln(os.Stderr, message)
+			},
+			Materialize: func(l lease.Lease, secret string) (grantflow.Materialized, error) {
+				leases, shellCommands, err := processLease(cmd, l, secret, leaseSet.Root, leaseSet.ConfigFile)
+				return grantflow.Materialized{Leases: leases, ShellCommands: shellCommands}, err
+			},
 		}
+		result, err := flow.Run(leaseSet, grantflow.Options{
+			Interactive:     interactive,
+			ContinueOnError: continueOnError,
+			Append:          appendMode,
+			Override:        override,
+		})
+		if err != nil {
+			return err
+		}
+		if result.Noop {
+			return nil
+		}
+
 		// If in test mode, don't try to send to the daemon.
 		if os.Getenv("ENV_LEASE_TEST") == "1" {
 			fmt.Fprintln(os.Stderr, "Grant request (test mode) processed successfully.")
-			if len(errs) > 0 {
-				return &GrantErrors{errs: errs}
-			}
 			return nil
 		}
 
 		if client != nil {
 			var resp ipc.GrantResponse
-			if err := client.Send(req, &resp); err != nil {
+			if err := client.Send(result.Request, &resp); err != nil {
 				handleClientError(err)
 			}
 			for _, msg := range resp.Messages {
@@ -331,17 +181,13 @@ This can be overridden with the --destination-outside-root flag.`,
 			fmt.Fprintln(os.Stderr, "Grant request processed in test mode.")
 		}
 
-		noDirenv, _ := cmd.Flags().GetBool("no-direnv")
-		for _, l := range leases {
-			if filepath.Base(l.Destination) == ".envrc" {
-				HandleDirenv(noDirenv, os.Stderr)
-				break
-			}
+		if result.NeedsDirenv() {
+			HandleDirenv(noDirenv, os.Stderr)
 		}
 
 		if shellMode {
 			fmt.Fprintln(os.Stderr, "# When using shell lease types run this command like `eval $(env-lease grant)`")
-			for _, cmd := range shellCommands {
+			for _, cmd := range result.ShellCommands {
 				fmt.Println(cmd)
 			}
 		}
@@ -431,254 +277,4 @@ func init() {
 	grantCmd.Flags().Bool("append", false, "In interactive mode, keep existing granted leases and only add newly approved leases. Skipped prompts are left unchanged.")
 	grantCmd.Flags().Bool("destination-outside-root", false, "Allow file-based leases to write outside of the project root.")
 	rootCmd.AddCommand(grantCmd)
-}
-
-// getTransformSummary creates a short, human-readable summary of the transform pipeline.
-func getTransformSummary(transforms []string) string {
-	if len(transforms) == 0 {
-		return ""
-	}
-	return fmt.Sprintf(" (%s)", strings.Join(transforms, ", "))
-}
-
-// interactiveGrant orchestrates the user-facing interactive lease approval process.
-// It is designed around a multi-phase workflow to provide a clear, consistent,
-// and secure user experience, deferring all secret lookups until after the user
-// has explicitly approved them.
-//
-// The function executes the following distinct phases:
-//
-// ### Phase 1: Round 1 - Approve Sources
-// The function first makes a complete pass through all `[[lease]]` blocks from
-// the configuration. It generates a descriptive prompt for each lease, including
-// transformation details for `explode` leases to avoid ambiguity. It collects
-// all of the user's 'yes' or 'no' responses for these top-level sources
-// without fetching any secrets.
-//
-// ### Phase 2: Fetch Secrets
-// After Round 1 is complete, the function identifies all unique secret sources
-// that need to be fetched based on the user's approvals. It then fetches these
-// secrets in parallel to maximize efficiency:
-//   - `op://` sources are grouped by `op_account` and fetched in batches.
-//   - `op+file://` sources are fetched individually, with the content of each
-//     unique URI being fetched only once and then cached for the remainder of the
-//     run.
-//
-// ### Phase 3: Round 2 - Approve Individual Secrets (Optional)
-// If any of the leases approved in Round 1 were `explode` leases, this phase
-// begins. The function iterates through the now-fetched and parsed secrets and
-// prompts the user to approve each individual key-value pair that resulted from
-// the `explode` transformation. Simple, non-exploding leases that were approved
-// in Round 1 are considered final and are not part of this phase.
-//
-// ### Phase 4: Grant Leases
-// Finally, the function gathers all the approved leases (both simple leases from
-// Round 1 and sub-leases from Round 2) into a single list and sends it to the
-// `env-lease` daemon to be activated. It also handles the output of any shell
-// commands for `shell` type leases.
-func interactiveGrant(cmd *cobra.Command, leaseSet *lease.Set, client *ipc.Client) error {
-	slog.Debug("interactive grant: phase 1 start", "lease_count", len(leaseSet.Leases))
-	// ------- Phase 1: ROUND 1 – APPROVE SOURCES -------
-	selectedLeases := make([]lease.Lease, 0, len(leaseSet.Leases))
-	for _, l := range leaseSet.Leases {
-		isExplode := l.IsExplode()
-
-		var key string
-		if isExplode {
-			// Descriptive label with transformation breadcrumbs
-			key = fmt.Sprintf("leases from '%s'%s", l.Source, getTransformSummary(l.Transform))
-		} else if l.Variable != "" {
-			key = fmt.Sprintf("'%s'", l.Variable)
-		} else {
-			key = fmt.Sprintf("'%s'", l.Source)
-		}
-
-		if confirm(fmt.Sprintf("Grant %s?", key)) {
-			selectedLeases = append(selectedLeases, l)
-		}
-	}
-
-	if len(selectedLeases) == 0 {
-		fmt.Fprintln(os.Stderr, "No leases selected.")
-		return nil
-	}
-
-	slog.Debug("interactive grant: phase 1 approvals",
-		"selected_count", len(selectedLeases),
-		"skipped_count", len(leaseSet.Leases)-len(selectedLeases))
-
-	continueOnError, _ := cmd.Flags().GetBool("continue-on-error")
-	override, _ := cmd.Flags().GetBool("override")
-	appendMode, _ := cmd.Flags().GetBool("append")
-	noDirenv, _ := cmd.Flags().GetBool("no-direnv")
-
-	if appendMode {
-		fmt.Fprintln(os.Stderr, "Append mode enabled: skipped leases will remain unchanged.")
-	}
-
-	var errs []grantError
-
-	fetched, fetchErrs, fetchErr := secretlookup.Fetch(selectedLeases, secretlookup.Options{ContinueOnError: continueOnError, Mode: "interactive"})
-	errs = append(errs, lookupGrantErrors(fetchErrs)...)
-	if fetchErr != nil {
-		return &GrantErrors{errs: errs}
-	}
-
-	// Pre-compute transform results without writing or prompting.
-	type child struct {
-		lease lease.Lease
-		value string
-	}
-	type simple struct {
-		lease lease.Lease
-		value string
-	}
-	explodedChildren := make([]child, 0)
-	simpleApproved := make([]simple, 0)
-	parentApproved := make([]ipc.Lease, 0)
-
-	slog.Debug("interactive grant: preprocessing transforms",
-		"selected_count", len(selectedLeases))
-
-	for _, l := range selectedLeases {
-		isExplode := l.IsExplode()
-		raw, ok := fetched.Get(l)
-		if !ok {
-			errs = append(errs, grantError{Source: l.Source, Err: fmt.Errorf("no secret returned")})
-			if !continueOnError {
-				return &GrantErrors{errs: errs}
-			}
-			continue
-		}
-
-		formatted := l
-		slog.Debug("interactive grant: preparing lease",
-			"source", formatted.Source,
-			"explode", isExplode,
-			"transform_steps", len(formatted.Transform))
-
-		result, err := transform.Apply(formatted, raw)
-		if err != nil {
-			errs = append(errs, grantError{Source: formatted.Source, Err: err})
-			if !continueOnError {
-				return &GrantErrors{errs: errs}
-			}
-			continue
-		}
-
-		if result.IsExploded() {
-			slog.Debug("interactive grant: explode result",
-				"source", formatted.Source,
-				"child_count", len(result.Secrets))
-
-			parentLeases, _, err := processLease(cmd, *result.Parent, "", leaseSet.Root, leaseSet.ConfigFile)
-			if err != nil {
-				errs = append(errs, grantError{Source: formatted.Source, Err: err})
-				if !continueOnError {
-					return &GrantErrors{errs: errs}
-				}
-				continue
-			}
-			if len(parentLeases) == 0 {
-				errs = append(errs, grantError{Source: formatted.Source, Err: fmt.Errorf("explode parent produced no leases")})
-				if !continueOnError {
-					return &GrantErrors{errs: errs}
-				}
-				continue
-			}
-
-			parentApproved = append(parentApproved, parentLeases...)
-			for _, transformedSecret := range result.Secrets {
-				explodedChildren = append(explodedChildren, child{
-					lease: transformedSecret.Lease,
-					value: transformedSecret.Value,
-				})
-			}
-			continue
-		}
-
-		for _, transformedSecret := range result.Secrets {
-			slog.Debug("interactive grant: pipeline produced single value", "source", transformedSecret.Lease.Source)
-			simpleApproved = append(simpleApproved, simple{lease: transformedSecret.Lease, value: transformedSecret.Value})
-		}
-	}
-
-	// ------- Phase 3: ROUND 2 – APPROVE INDIVIDUAL SECRETS FOR EXPLODE -------
-	slog.Debug("interactive grant: phase 3 start",
-		"simple_count", len(simpleApproved),
-		"explode_children", len(explodedChildren))
-	finalLeases := make([]ipc.Lease, 0)
-	approvedShellCommands := make([]string, 0)
-
-	finalLeases = append(finalLeases, parentApproved...)
-
-	// First, materialize all simple leases (no new prompts)
-	for _, approved := range simpleApproved {
-		l := approved.lease
-		leas, sc, err := processLease(cmd, l, approved.value, leaseSet.Root, leaseSet.ConfigFile)
-		if err != nil {
-			errs = append(errs, grantError{Source: l.Source, Err: err})
-			if !continueOnError {
-				return &GrantErrors{errs: errs}
-			}
-			continue
-		}
-		finalLeases = append(finalLeases, leas...)
-		approvedShellCommands = append(approvedShellCommands, sc...)
-	}
-
-	// Then, prompt for exploded keys
-	// Group by parent source only for nice prompts
-	for _, ch := range explodedChildren {
-		prompt := fmt.Sprintf("Grant lease for '%s'?", ch.lease.Variable)
-		if !confirm(prompt) {
-			continue
-		}
-		leas, sc, err := processLease(cmd, ch.lease, ch.value, leaseSet.Root, leaseSet.ConfigFile)
-		if err != nil {
-			errs = append(errs, grantError{Source: ch.lease.Source, Err: err})
-			if !continueOnError {
-				return &GrantErrors{errs: errs}
-			}
-			continue
-		}
-		finalLeases = append(finalLeases, leas...)
-		approvedShellCommands = append(approvedShellCommands, sc...)
-	}
-
-	if len(errs) > 0 && !continueOnError {
-		return &GrantErrors{errs: errs}
-	}
-
-	// ------- Phase 4: GRANT (single request) -------
-	slog.Debug("interactive grant: phase 4 start", "final_lease_count", len(finalLeases))
-	req := ipc.GrantRequest{Command: "grant", Leases: finalLeases, Override: override, Append: appendMode, ConfigFile: leaseSet.ConfigFile}
-	if client != nil {
-		var resp ipc.GrantResponse
-		if err := client.Send(req, &resp); err != nil {
-			handleClientError(err)
-		}
-		for _, msg := range resp.Messages {
-			fmt.Fprintln(os.Stderr, msg)
-		}
-	} else {
-		fmt.Fprintln(os.Stderr, "Grant request processed in test mode.")
-	}
-
-	for _, l := range finalLeases {
-		if filepath.Base(l.Destination) == ".envrc" {
-			HandleDirenv(noDirenv, os.Stderr)
-			break
-		}
-	}
-
-	if shellMode {
-		fmt.Fprintln(os.Stderr, "# When using shell lease types run this command like `eval $(env-lease grant)`")
-		for _, c := range approvedShellCommands {
-			fmt.Println(c)
-		}
-	}
-
-	fmt.Fprintln(os.Stderr, "Grant request sent successfully.")
-	return nil
 }

--- a/cmd/grant.go
+++ b/cmd/grant.go
@@ -156,7 +156,7 @@ This can be overridden with the --destination-outside-root flag.`,
 			Append:          appendMode,
 			Override:        override,
 		})
-		if err != nil {
+		if err != nil && len(result.Request.Leases) == 0 {
 			return err
 		}
 		if result.Noop {
@@ -166,7 +166,7 @@ This can be overridden with the --destination-outside-root flag.`,
 		// If in test mode, don't try to send to the daemon.
 		if os.Getenv("ENV_LEASE_TEST") == "1" {
 			fmt.Fprintln(os.Stderr, "Grant request (test mode) processed successfully.")
-			return nil
+			return err
 		}
 
 		if client != nil {
@@ -192,7 +192,7 @@ This can be overridden with the --destination-outside-root flag.`,
 			}
 		}
 		fmt.Fprintln(os.Stderr, "Grant request sent successfully.")
-		return nil
+		return err
 	},
 }
 

--- a/internal/grantflow/errors.go
+++ b/internal/grantflow/errors.go
@@ -1,0 +1,40 @@
+package grantflow
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Error associates a Grant workflow failure with the Lease source that caused it.
+type Error struct {
+	Source string
+	Err    error
+}
+
+// Errors is the aggregated Grant workflow error shown by the CLI.
+type Errors struct {
+	errs []Error
+}
+
+// List returns the underlying per-Lease errors.
+func (e Errors) List() []Error {
+	return append([]Error(nil), e.errs...)
+}
+
+func (e Errors) Error() string {
+	var sb strings.Builder
+	if len(e.errs) > 1 {
+		sb.WriteString(fmt.Sprintf("Failed to grant %d leases:\n\n", len(e.errs)))
+	} else {
+		sb.WriteString("Failed to grant lease:\n\n")
+	}
+	for _, ge := range e.errs {
+		sb.WriteString(fmt.Sprintf("Lease: %s\n", ge.Source))
+		sb.WriteString(fmt.Sprintf("└─ Error: %s\n\n", ge.Err))
+	}
+
+	if len(e.errs) > 1 {
+		sb.WriteString("Note: Other leases may have been granted successfully.\n")
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}

--- a/internal/grantflow/flow.go
+++ b/internal/grantflow/flow.go
@@ -165,9 +165,6 @@ func (f Flow) runInteractive(set *lease.Set, opts Options) (Result, error) {
 	if len(errs) > 0 && !opts.ContinueOnError {
 		return Result{}, Errors{errs: errs}
 	}
-	if len(errs) > 0 {
-		return Result{}, Errors{errs: errs}
-	}
 	return result, nil
 }
 

--- a/internal/grantflow/flow.go
+++ b/internal/grantflow/flow.go
@@ -1,0 +1,388 @@
+// Package grantflow owns Grant workflow orchestration.
+package grantflow
+
+import (
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mblarsen/env-lease/internal/ipc"
+	"github.com/mblarsen/env-lease/internal/lease"
+	"github.com/mblarsen/env-lease/internal/secretlookup"
+	"github.com/mblarsen/env-lease/internal/transform"
+)
+
+// ConfirmFunc asks the user whether a Grant step should proceed.
+type ConfirmFunc func(prompt string) bool
+
+// NoticeFunc reports non-secret workflow messages to the caller.
+type NoticeFunc func(message string)
+
+// MaterializeFunc materializes one transformed Secret and returns the Lease data
+// that should be registered with the Daemon.
+type MaterializeFunc func(l lease.Lease, secret string) (Materialized, error)
+
+// Materialized is the observable output of materializing one Secret.
+type Materialized struct {
+	Leases        []ipc.Lease
+	ShellCommands []string
+}
+
+// Options controls Grant workflow behaviour.
+type Options struct {
+	Interactive     bool
+	ContinueOnError bool
+	Append          bool
+	Override        bool
+}
+
+// Result is the final output of a Grant workflow before IPC delivery.
+type Result struct {
+	Request       ipc.GrantRequest
+	ShellCommands []string
+	Noop          bool
+}
+
+// Flow runs Grant workflows for a normalized Lease set.
+type Flow struct {
+	Confirm     ConfirmFunc
+	Notice      NoticeFunc
+	Materialize MaterializeFunc
+	Lookup      *secretlookup.Lookup
+}
+
+// Run executes either the non-interactive or interactive Grant workflow.
+func (f Flow) Run(set *lease.Set, opts Options) (Result, error) {
+	if set == nil {
+		return Result{}, fmt.Errorf("lease set is nil")
+	}
+	if f.Materialize == nil {
+		return Result{}, fmt.Errorf("materializer is nil")
+	}
+	if f.Lookup == nil {
+		f.Lookup = secretlookup.New()
+	}
+	if f.Notice == nil {
+		f.Notice = func(string) {}
+	}
+
+	var result Result
+	var err error
+	if opts.Interactive {
+		result, err = f.runInteractive(set, opts)
+	} else {
+		result, err = f.runNonInteractive(set, opts)
+	}
+	if err != nil {
+		return Result{}, err
+	}
+	if result.Noop {
+		return result, nil
+	}
+
+	result.Request = ipc.GrantRequest{
+		Command:    "grant",
+		Leases:     result.Request.Leases,
+		Override:   opts.Override,
+		Append:     opts.Append,
+		ConfigFile: set.ConfigFile,
+	}
+	return result, nil
+}
+
+func (f Flow) runNonInteractive(set *lease.Set, opts Options) (Result, error) {
+	var errs []Error
+	var result Result
+
+	fetched, lookupErrs, fetchErr := f.Lookup.Fetch(set.Leases, secretlookup.Options{ContinueOnError: opts.ContinueOnError, Mode: "non-interactive"})
+	errs = append(errs, lookupGrantErrors(lookupErrs)...)
+	if fetchErr != nil {
+		return Result{}, Errors{errs: errs}
+	}
+
+	for _, l := range set.Leases {
+		raw, ok := fetched.Get(l)
+		if !ok {
+			if !hasErrorForSource(errs, l.Source) {
+				errs = append(errs, Error{Source: l.Source, Err: fmt.Errorf("no secret returned")})
+			}
+			if !opts.ContinueOnError {
+				return Result{}, Errors{errs: errs}
+			}
+			continue
+		}
+
+		materialized, err := f.applyAndMaterialize(l, raw)
+		if err != nil {
+			errs = append(errs, Error{Source: l.Source, Err: err})
+			if !opts.ContinueOnError {
+				return Result{}, Errors{errs: errs}
+			}
+			continue
+		}
+		result.append(materialized)
+	}
+
+	if len(errs) > 0 {
+		return Result{}, Errors{errs: errs}
+	}
+	return result, nil
+}
+
+func (f Flow) runInteractive(set *lease.Set, opts Options) (Result, error) {
+	slog.Debug("interactive grant: phase 1 start", "lease_count", len(set.Leases))
+	selectedLeases := f.approveSources(set.Leases)
+	if len(selectedLeases) == 0 {
+		f.Notice("No leases selected.")
+		return Result{Noop: true}, nil
+	}
+
+	slog.Debug("interactive grant: phase 1 approvals",
+		"selected_count", len(selectedLeases),
+		"skipped_count", len(set.Leases)-len(selectedLeases))
+
+	if opts.Append {
+		f.Notice("Append mode enabled: skipped leases will remain unchanged.")
+	}
+
+	var errs []Error
+	fetched, lookupErrs, fetchErr := f.Lookup.Fetch(selectedLeases, secretlookup.Options{ContinueOnError: opts.ContinueOnError, Mode: "interactive"})
+	errs = append(errs, lookupGrantErrors(lookupErrs)...)
+	if fetchErr != nil {
+		return Result{}, Errors{errs: errs}
+	}
+
+	prepared, prepareErrs := f.prepareInteractive(selectedLeases, fetched, opts)
+	errs = append(errs, prepareErrs...)
+	if len(prepareErrs) > 0 && !opts.ContinueOnError {
+		return Result{}, Errors{errs: errs}
+	}
+
+	result, materializeErrs := f.materializeInteractive(prepared, opts)
+	errs = append(errs, materializeErrs...)
+	if len(errs) > 0 && !opts.ContinueOnError {
+		return Result{}, Errors{errs: errs}
+	}
+	if len(errs) > 0 {
+		return Result{}, Errors{errs: errs}
+	}
+	return result, nil
+}
+
+func (f Flow) approveSources(leases []lease.Lease) []lease.Lease {
+	selected := make([]lease.Lease, 0, len(leases))
+	for _, l := range leases {
+		if f.confirm(promptForSource(l)) {
+			selected = append(selected, l)
+		}
+	}
+	return selected
+}
+
+type preparedInteractive struct {
+	simpleApproved   []transform.Secret
+	explodedChildren []transform.Secret
+	parentApproved   []ipc.Lease
+}
+
+func (f Flow) prepareInteractive(selected []lease.Lease, fetched secretlookup.Secrets, opts Options) (preparedInteractive, []Error) {
+	prepared := preparedInteractive{}
+	var errs []Error
+
+	slog.Debug("interactive grant: preprocessing transforms", "selected_count", len(selected))
+	for _, l := range selected {
+		raw, ok := fetched.Get(l)
+		if !ok {
+			errs = append(errs, Error{Source: l.Source, Err: fmt.Errorf("no secret returned")})
+			if !opts.ContinueOnError {
+				return prepared, errs
+			}
+			continue
+		}
+
+		slog.Debug("interactive grant: preparing lease",
+			"source", l.Source,
+			"explode", l.IsExplode(),
+			"transform_steps", len(l.Transform))
+
+		transformResult, err := applyTransform(l, raw)
+		if err != nil {
+			errs = append(errs, Error{Source: l.Source, Err: err})
+			if !opts.ContinueOnError {
+				return prepared, errs
+			}
+			continue
+		}
+
+		if transformResult.IsExploded() {
+			slog.Debug("interactive grant: explode result", "source", l.Source, "child_count", len(transformResult.Secrets))
+			parent, err := f.Materialize(*transformResult.Parent, "")
+			if err != nil {
+				errs = append(errs, Error{Source: l.Source, Err: err})
+				if !opts.ContinueOnError {
+					return prepared, errs
+				}
+				continue
+			}
+			if len(parent.Leases) == 0 {
+				errs = append(errs, Error{Source: l.Source, Err: fmt.Errorf("explode parent produced no leases")})
+				if !opts.ContinueOnError {
+					return prepared, errs
+				}
+				continue
+			}
+			prepared.parentApproved = append(prepared.parentApproved, parent.Leases...)
+			prepared.explodedChildren = append(prepared.explodedChildren, transformResult.Secrets...)
+			continue
+		}
+
+		for _, transformedSecret := range transformResult.Secrets {
+			slog.Debug("interactive grant: pipeline produced single value", "source", transformedSecret.Lease.Source)
+			prepared.simpleApproved = append(prepared.simpleApproved, transformedSecret)
+		}
+	}
+
+	return prepared, errs
+}
+
+func (f Flow) materializeInteractive(prepared preparedInteractive, opts Options) (Result, []Error) {
+	slog.Debug("interactive grant: phase 3 start",
+		"simple_count", len(prepared.simpleApproved),
+		"explode_children", len(prepared.explodedChildren))
+
+	var result Result
+	var errs []Error
+	result.Request.Leases = append(result.Request.Leases, prepared.parentApproved...)
+
+	for _, secret := range prepared.simpleApproved {
+		materialized, err := f.Materialize(secret.Lease, secret.Value)
+		if err != nil {
+			errs = append(errs, Error{Source: secret.Lease.Source, Err: err})
+			if !opts.ContinueOnError {
+				return result, errs
+			}
+			continue
+		}
+		result.append(materialized)
+	}
+
+	for _, secret := range prepared.explodedChildren {
+		if !f.confirm(fmt.Sprintf("Grant lease for '%s'?", secret.Lease.Variable)) {
+			continue
+		}
+		materialized, err := f.Materialize(secret.Lease, secret.Value)
+		if err != nil {
+			errs = append(errs, Error{Source: secret.Lease.Source, Err: err})
+			if !opts.ContinueOnError {
+				return result, errs
+			}
+			continue
+		}
+		result.append(materialized)
+	}
+
+	return result, errs
+}
+
+func (f Flow) applyAndMaterialize(l lease.Lease, raw string) (Materialized, error) {
+	warnLongLease(l)
+	transformResult, err := applyTransform(l, raw)
+	if err != nil {
+		return Materialized{}, fmt.Errorf("failed to transform secret: %w", err)
+	}
+
+	var materialized Materialized
+	if transformResult.IsExploded() {
+		f.Notice(fmt.Sprintf("Granting sub-leases from '%s'%s:", l.Source, transformSummary(l.Transform)))
+		parent, err := f.Materialize(*transformResult.Parent, "")
+		if err != nil {
+			return Materialized{}, err
+		}
+		materialized.append(parent)
+	}
+
+	for _, transformedSecret := range transformResult.Secrets {
+		m, err := f.Materialize(transformedSecret.Lease, transformedSecret.Value)
+		if err != nil {
+			return Materialized{}, err
+		}
+		materialized.append(m)
+	}
+	return materialized, nil
+}
+
+func applyTransform(l lease.Lease, raw string) (transform.Result, error) {
+	return transform.Apply(l, raw)
+}
+
+func (f Flow) confirm(prompt string) bool {
+	if f.Confirm == nil {
+		return false
+	}
+	return f.Confirm(prompt)
+}
+
+func (r *Result) append(materialized Materialized) {
+	r.Request.Leases = append(r.Request.Leases, materialized.Leases...)
+	r.ShellCommands = append(r.ShellCommands, materialized.ShellCommands...)
+}
+
+func (m *Materialized) append(other Materialized) {
+	m.Leases = append(m.Leases, other.Leases...)
+	m.ShellCommands = append(m.ShellCommands, other.ShellCommands...)
+}
+
+func promptForSource(l lease.Lease) string {
+	var key string
+	if l.IsExplode() {
+		key = fmt.Sprintf("leases from '%s'%s", l.Source, transformSummary(l.Transform))
+	} else if l.Variable != "" {
+		key = fmt.Sprintf("'%s'", l.Variable)
+	} else {
+		key = fmt.Sprintf("'%s'", l.Source)
+	}
+	return fmt.Sprintf("Grant %s?", key)
+}
+
+func transformSummary(transforms []string) string {
+	if len(transforms) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (%s)", strings.Join(transforms, ", "))
+}
+
+func warnLongLease(l lease.Lease) {
+	duration, err := time.ParseDuration(l.Duration)
+	if err == nil && duration > 12*time.Hour {
+		slog.Warn("Leases longer than 12 hours are discouraged for security reasons.")
+	}
+}
+
+func lookupGrantErrors(lookupErrs []secretlookup.Error) []Error {
+	errs := make([]Error, 0, len(lookupErrs))
+	for _, lookupErr := range lookupErrs {
+		errs = append(errs, Error{Source: lookupErr.Lease.Source, Err: lookupErr.Err})
+	}
+	return errs
+}
+
+func hasErrorForSource(errs []Error, source string) bool {
+	for _, err := range errs {
+		if err.Source == source {
+			return true
+		}
+	}
+	return false
+}
+
+// NeedsDirenv reports whether a Grant result touched a .envrc destination.
+func (r Result) NeedsDirenv() bool {
+	for _, l := range r.Request.Leases {
+		if filepath.Base(l.Destination) == ".envrc" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/grantflow/flow.go
+++ b/internal/grantflow/flow.go
@@ -75,8 +75,8 @@ func (f Flow) Run(set *lease.Set, opts Options) (Result, error) {
 	} else {
 		result, err = f.runNonInteractive(set, opts)
 	}
-	if err != nil {
-		return Result{}, err
+	if err != nil && len(result.Request.Leases) == 0 {
+		return result, err
 	}
 	if result.Noop {
 		return result, nil
@@ -89,7 +89,7 @@ func (f Flow) Run(set *lease.Set, opts Options) (Result, error) {
 		Append:     opts.Append,
 		ConfigFile: set.ConfigFile,
 	}
-	return result, nil
+	return result, err
 }
 
 func (f Flow) runNonInteractive(set *lease.Set, opts Options) (Result, error) {
@@ -114,19 +114,20 @@ func (f Flow) runNonInteractive(set *lease.Set, opts Options) (Result, error) {
 			continue
 		}
 
-		materialized, err := f.applyAndMaterialize(l, raw)
-		if err != nil {
-			errs = append(errs, Error{Source: l.Source, Err: err})
+		materialized, materializeErrs := f.applyAndMaterialize(l, raw, opts.ContinueOnError)
+		if len(materializeErrs) > 0 {
+			errs = append(errs, materializeErrs...)
 			if !opts.ContinueOnError {
 				return Result{}, Errors{errs: errs}
 			}
+			result.append(materialized)
 			continue
 		}
 		result.append(materialized)
 	}
 
 	if len(errs) > 0 {
-		return Result{}, Errors{errs: errs}
+		return result, Errors{errs: errs}
 	}
 	return result, nil
 }
@@ -283,19 +284,20 @@ func (f Flow) materializeInteractive(prepared preparedInteractive, opts Options)
 	return result, errs
 }
 
-func (f Flow) applyAndMaterialize(l lease.Lease, raw string) (Materialized, error) {
+func (f Flow) applyAndMaterialize(l lease.Lease, raw string, continueOnError bool) (Materialized, []Error) {
 	warnLongLease(l)
 	transformResult, err := applyTransform(l, raw)
 	if err != nil {
-		return Materialized{}, fmt.Errorf("failed to transform secret: %w", err)
+		return Materialized{}, []Error{{Source: l.Source, Err: fmt.Errorf("failed to transform secret: %w", err)}}
 	}
 
 	var materialized Materialized
+	var errs []Error
 	if transformResult.IsExploded() {
 		f.Notice(fmt.Sprintf("Granting sub-leases from '%s'%s:", l.Source, transformSummary(l.Transform)))
 		parent, err := f.Materialize(*transformResult.Parent, "")
 		if err != nil {
-			return Materialized{}, err
+			return Materialized{}, []Error{{Source: l.Source, Err: err}}
 		}
 		materialized.append(parent)
 	}
@@ -303,11 +305,15 @@ func (f Flow) applyAndMaterialize(l lease.Lease, raw string) (Materialized, erro
 	for _, transformedSecret := range transformResult.Secrets {
 		m, err := f.Materialize(transformedSecret.Lease, transformedSecret.Value)
 		if err != nil {
-			return Materialized{}, err
+			errs = append(errs, materializeError(transformedSecret.Lease, err))
+			if !continueOnError {
+				return materialized, errs
+			}
+			continue
 		}
 		materialized.append(m)
 	}
-	return materialized, nil
+	return materialized, errs
 }
 
 func applyTransform(l lease.Lease, raw string) (transform.Result, error) {
@@ -372,6 +378,13 @@ func hasErrorForSource(errs []Error, source string) bool {
 		}
 	}
 	return false
+}
+
+func materializeError(l lease.Lease, err error) Error {
+	if l.ParentSource != "" && l.Variable != "" {
+		return Error{Source: l.Variable, Err: err}
+	}
+	return Error{Source: l.Source, Err: err}
 }
 
 // NeedsDirenv reports whether a Grant result touched a .envrc destination.

--- a/internal/grantflow/flow_test.go
+++ b/internal/grantflow/flow_test.go
@@ -1,6 +1,7 @@
 package grantflow
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -137,6 +138,34 @@ func TestRunInteractiveContinueOnLookupErrorReturnsSuccessfulGrant(t *testing.T)
 	wantCalls := []string{"SUCCESS_KEY=secret-for-mock"}
 	if !reflect.DeepEqual(gotCalls, wantCalls) {
 		t.Fatalf("materializer calls mismatch\nwant: %#v\n got: %#v", wantCalls, gotCalls)
+	}
+}
+
+func TestRunNonInteractiveContinueOnExplodedChildErrorReturnsSuccessfulSiblings(t *testing.T) {
+	t.Setenv("ENV_LEASE_TEST", "1")
+
+	flow := Flow{
+		Notice: func(string) {},
+		Materialize: func(l lease.Lease, secret string) (Materialized, error) {
+			if l.Variable == "KEY2" {
+				return Materialized{}, errors.New("cannot write KEY2")
+			}
+			return Materialized{Leases: []ipc.Lease{l.ToIPC()}}, nil
+		},
+	}
+
+	result, err := flow.Run(testSet(testExplodeLease("mock-explode")), Options{ContinueOnError: true})
+	if err == nil {
+		t.Fatal("expected aggregated error")
+	}
+	if !strings.Contains(err.Error(), "Lease: KEY2") {
+		t.Fatalf("expected KEY2 in error, got %v", err)
+	}
+
+	gotVariables := variablesFromLeases(result.Request.Leases)
+	wantVariables := []string{"", "KEY1"}
+	if !reflect.DeepEqual(gotVariables, wantVariables) {
+		t.Fatalf("variables mismatch\nwant: %#v\n got: %#v", wantVariables, gotVariables)
 	}
 }
 

--- a/internal/grantflow/flow_test.go
+++ b/internal/grantflow/flow_test.go
@@ -109,6 +109,37 @@ func TestRunInteractiveNoSelectionIsNoop(t *testing.T) {
 	}
 }
 
+func TestRunInteractiveContinueOnLookupErrorReturnsSuccessfulGrant(t *testing.T) {
+	t.Setenv("ENV_LEASE_TEST", "1")
+
+	var calls []materializeCall
+	flow := Flow{
+		Confirm:     func(string) bool { return true },
+		Materialize: recordingMaterializer(&calls),
+	}
+	set := testSet(
+		testEnvLease("mock-fail", "FAIL_KEY"),
+		testEnvLease("mock", "SUCCESS_KEY"),
+	)
+
+	result, err := flow.Run(set, Options{Interactive: true, ContinueOnError: true})
+	if err != nil {
+		t.Fatalf("expected successful partial grant result, got %v", err)
+	}
+
+	gotVariables := variablesFromLeases(result.Request.Leases)
+	wantVariables := []string{"SUCCESS_KEY"}
+	if !reflect.DeepEqual(gotVariables, wantVariables) {
+		t.Fatalf("variables mismatch\nwant: %#v\n got: %#v", wantVariables, gotVariables)
+	}
+
+	gotCalls := callVariablesAndValues(calls)
+	wantCalls := []string{"SUCCESS_KEY=secret-for-mock"}
+	if !reflect.DeepEqual(gotCalls, wantCalls) {
+		t.Fatalf("materializer calls mismatch\nwant: %#v\n got: %#v", wantCalls, gotCalls)
+	}
+}
+
 func TestRunNonInteractiveContinueOnLookupErrorMaterializesSuccessfulLeases(t *testing.T) {
 	t.Setenv("ENV_LEASE_TEST", "1")
 

--- a/internal/grantflow/flow_test.go
+++ b/internal/grantflow/flow_test.go
@@ -1,0 +1,195 @@
+package grantflow
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/mblarsen/env-lease/internal/ipc"
+	"github.com/mblarsen/env-lease/internal/lease"
+)
+
+func TestRunNonInteractiveMaterializesSimpleAndExplodedLeases(t *testing.T) {
+	t.Setenv("ENV_LEASE_TEST", "1")
+
+	var calls []materializeCall
+	flow := Flow{Materialize: recordingMaterializer(&calls), Notice: func(string) {}}
+	set := testSet(
+		testEnvLease("mock-simple", "SIMPLE_KEY"),
+		testExplodeLease("mock-explode"),
+	)
+
+	result, err := flow.Run(set, Options{Override: true})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if !result.Request.Override {
+		t.Fatal("expected override to be carried into grant request")
+	}
+	if result.Request.ConfigFile != set.ConfigFile {
+		t.Fatalf("expected config file %q, got %q", set.ConfigFile, result.Request.ConfigFile)
+	}
+
+	gotVariables := variablesFromLeases(result.Request.Leases)
+	wantVariables := []string{"SIMPLE_KEY", "", "KEY1", "KEY2"}
+	if !reflect.DeepEqual(gotVariables, wantVariables) {
+		t.Fatalf("variables mismatch\nwant: %#v\n got: %#v", wantVariables, gotVariables)
+	}
+
+	gotCalls := callVariablesAndValues(calls)
+	wantCalls := []string{"SIMPLE_KEY=secret-for-mock-simple", "=", "KEY1=VALUE1", "KEY2=VALUE2"}
+	if !reflect.DeepEqual(gotCalls, wantCalls) {
+		t.Fatalf("materializer calls mismatch\nwant: %#v\n got: %#v", wantCalls, gotCalls)
+	}
+}
+
+func TestRunInteractiveKeepsRoundOnePromptsBeforeExplodedChildren(t *testing.T) {
+	t.Setenv("ENV_LEASE_TEST", "1")
+
+	var prompts []string
+	var calls []materializeCall
+	flow := Flow{
+		Confirm: func(prompt string) bool {
+			prompts = append(prompts, prompt)
+			return true
+		},
+		Materialize: recordingMaterializer(&calls),
+	}
+	set := testSet(
+		testEnvLease("mock-simple", "SIMPLE_KEY"),
+		testExplodeLease("mock-explode"),
+	)
+
+	result, err := flow.Run(set, Options{Interactive: true})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	wantPrompts := []string{
+		"Grant 'SIMPLE_KEY'?",
+		"Grant leases from 'mock-explode' (json, explode)?",
+		"Grant lease for 'KEY1'?",
+		"Grant lease for 'KEY2'?",
+	}
+	if !reflect.DeepEqual(prompts, wantPrompts) {
+		t.Fatalf("prompts mismatch\nwant: %#v\n got: %#v", wantPrompts, prompts)
+	}
+
+	gotVariables := variablesFromLeases(result.Request.Leases)
+	wantVariables := []string{"", "SIMPLE_KEY", "KEY1", "KEY2"}
+	if !reflect.DeepEqual(gotVariables, wantVariables) {
+		t.Fatalf("variables mismatch\nwant: %#v\n got: %#v", wantVariables, gotVariables)
+	}
+}
+
+func TestRunInteractiveNoSelectionIsNoop(t *testing.T) {
+	t.Setenv("ENV_LEASE_TEST", "1")
+
+	var notices []string
+	var calls []materializeCall
+	flow := Flow{
+		Confirm:     func(string) bool { return false },
+		Notice:      func(message string) { notices = append(notices, message) },
+		Materialize: recordingMaterializer(&calls),
+	}
+
+	result, err := flow.Run(testSet(testEnvLease("mock-simple", "SIMPLE_KEY")), Options{Interactive: true})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if !result.Noop {
+		t.Fatal("expected no-op result")
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no materializer calls, got %d", len(calls))
+	}
+	if !reflect.DeepEqual(notices, []string{"No leases selected."}) {
+		t.Fatalf("unexpected notices: %#v", notices)
+	}
+}
+
+func TestRunNonInteractiveContinueOnLookupErrorMaterializesSuccessfulLeases(t *testing.T) {
+	t.Setenv("ENV_LEASE_TEST", "1")
+
+	var calls []materializeCall
+	flow := Flow{Materialize: recordingMaterializer(&calls)}
+	set := testSet(
+		testEnvLease("mock-fail", "FAIL_KEY"),
+		testEnvLease("mock", "SUCCESS_KEY"),
+	)
+
+	_, err := flow.Run(set, Options{ContinueOnError: true})
+	if err == nil {
+		t.Fatal("expected aggregated error")
+	}
+	if !strings.Contains(err.Error(), "Lease: mock-fail") {
+		t.Fatalf("expected mock-fail in error, got %v", err)
+	}
+
+	gotCalls := callVariablesAndValues(calls)
+	wantCalls := []string{"SUCCESS_KEY=secret-for-mock"}
+	if !reflect.DeepEqual(gotCalls, wantCalls) {
+		t.Fatalf("materializer calls mismatch\nwant: %#v\n got: %#v", wantCalls, gotCalls)
+	}
+}
+
+type materializeCall struct {
+	Lease lease.Lease
+	Value string
+}
+
+func recordingMaterializer(calls *[]materializeCall) MaterializeFunc {
+	return func(l lease.Lease, secret string) (Materialized, error) {
+		*calls = append(*calls, materializeCall{Lease: l, Value: secret})
+		return Materialized{Leases: []ipc.Lease{l.ToIPC()}}, nil
+	}
+}
+
+func testSet(leases ...lease.Lease) *lease.Set {
+	return &lease.Set{
+		Root:       "/tmp/project",
+		ConfigFile: "/tmp/project/env-lease.toml",
+		Leases:     leases,
+	}
+}
+
+func testEnvLease(source, variable string) lease.Lease {
+	return lease.Lease{
+		Provider:    "1password",
+		Source:      source,
+		Destination: "/tmp/project/.env",
+		Duration:    "1m",
+		LeaseType:   lease.TypeEnv,
+		Variable:    variable,
+		Format:      "%s=%q",
+	}
+}
+
+func testExplodeLease(source string) lease.Lease {
+	return lease.Lease{
+		Provider:    "1password",
+		Source:      source,
+		Destination: "/tmp/project/.env",
+		Duration:    "1m",
+		LeaseType:   lease.TypeEnv,
+		Transform:   []string{"json", "explode"},
+		Format:      "%s=%q",
+	}
+}
+
+func variablesFromLeases(leases []ipc.Lease) []string {
+	variables := make([]string, 0, len(leases))
+	for _, l := range leases {
+		variables = append(variables, l.Variable)
+	}
+	return variables
+}
+
+func callVariablesAndValues(calls []materializeCall) []string {
+	values := make([]string, 0, len(calls))
+	for _, call := range calls {
+		values = append(values, call.Lease.Variable+"="+call.Value)
+	}
+	return values
+}


### PR DESCRIPTION
## Summary
- add `internal/grantflow` to own Grant Workflow orchestration for interactive and non-interactive grants
- simplify `cmd/grant.go` so it handles CLI flags, config loading, IPC, and output plumbing
- add focused Grant Workflow tests and update project context language

## Testing
- `mise run lint`
- `mise run test`
- `git diff --check`
