### PR TITLE
feat: color status and grant prompts

### DIFF
--- a/cmd/color.go
+++ b/cmd/color.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/charmbracelet/x/term"
+)
+
+func colorsEnabled(output *os.File) bool {
+	return colorsEnabledWithEnv(output, os.LookupEnv)
+}
+
+func colorsEnabledWithEnv(output *os.File, lookupEnv func(string) (string, bool)) bool {
+	if _, disabled := lookupEnv("NO_COLOR"); disabled {
+		return false
+	}
+	if output == nil {
+		return false
+	}
+
+	return term.IsTerminal(output.Fd())
+}

--- a/cmd/color_test.go
+++ b/cmd/color_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestColorsEnabledRespectsNoColor(t *testing.T) {
+	assert.False(t, colorsEnabledWithEnv(os.Stdout, func(key string) (string, bool) {
+		if key == "NO_COLOR" {
+			return "1", true
+		}
+		return "", false
+	}))
+}
+
+func TestColorsEnabledRequiresTerminal(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "output")
+	require.NoError(t, err)
+	defer file.Close()
+
+	assert.False(t, colorsEnabledWithEnv(file, func(string) (string, bool) {
+		return "", false
+	}))
+}

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -55,7 +55,7 @@ func doConfirm(prompt string, in io.Reader) bool {
 	reader := bufio.NewReader(in)
 
 	for {
-		fmt.Printf("%s [y/n/a/d/?]: ", prompt)
+		fmt.Print(styleConfirmPrompt(prompt))
 		input, err := reader.ReadString('\n')
 		if err != nil {
 			// On EOF, default to "no"

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -55,7 +55,7 @@ func doConfirm(prompt string, in io.Reader) bool {
 	reader := bufio.NewReader(in)
 
 	for {
-		fmt.Print(styleConfirmPrompt(prompt))
+		fmt.Print(formatConfirmPrompt(prompt))
 		input, err := reader.ReadString('\n')
 		if err != nil {
 			// On EOF, default to "no"

--- a/cmd/prompt_style.go
+++ b/cmd/prompt_style.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"regexp"
+
+	"github.com/charmbracelet/lipgloss/v2"
+)
+
+var (
+	confirmPromptTextStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#94a3b8"))
+	confirmPromptQuoteStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#f8fafc"))
+	confirmPromptVariableStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("#38bdf8"))
+)
+
+var grantPromptPattern = regexp.MustCompile(`^(Grant) '([^']+)'([?])$`)
+
+func styleConfirmPrompt(prompt string) string {
+	return styleConfirmPromptText(prompt) + " " + styleConfirmOptions() + ": "
+}
+
+func styleConfirmPromptText(prompt string) string {
+	matches := grantPromptPattern.FindStringSubmatch(prompt)
+	if len(matches) == 4 {
+		return confirmPromptTextStyle.Render(matches[1]) +
+			" " +
+			confirmPromptQuoteStyle.Render("'") +
+			confirmPromptVariableStyle.Render(matches[2]) +
+			confirmPromptQuoteStyle.Render("'") +
+			confirmPromptTextStyle.Render(matches[3])
+	}
+
+	return confirmPromptTextStyle.Render(prompt)
+}
+
+func styleConfirmOptions() string {
+	return confirmPromptTextStyle.Render("[y/n/a/d/?]")
+}

--- a/cmd/prompt_style.go
+++ b/cmd/prompt_style.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"regexp"
 
 	"github.com/charmbracelet/lipgloss/v2"
@@ -15,7 +16,21 @@ var (
 					Foreground(lipgloss.Color("#38bdf8"))
 )
 
+const confirmOptionsText = "[y/n/a/d/?]"
+
 var grantPromptPattern = regexp.MustCompile(`^(Grant) '([^']+)'([?])$`)
+
+func formatConfirmPrompt(prompt string) string {
+	if !colorsEnabled(os.Stdout) {
+		return plainConfirmPrompt(prompt)
+	}
+
+	return styleConfirmPrompt(prompt)
+}
+
+func plainConfirmPrompt(prompt string) string {
+	return prompt + " " + confirmOptionsText + ": "
+}
 
 func styleConfirmPrompt(prompt string) string {
 	return styleConfirmPromptText(prompt) + " " + styleConfirmOptions() + ": "
@@ -36,5 +51,5 @@ func styleConfirmPromptText(prompt string) string {
 }
 
 func styleConfirmOptions() string {
-	return confirmPromptTextStyle.Render("[y/n/a/d/?]")
+	return confirmPromptTextStyle.Render(confirmOptionsText)
 }

--- a/cmd/prompt_style_test.go
+++ b/cmd/prompt_style_test.go
@@ -6,6 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFormatConfirmPromptPreservesPlainTextWhenNoColorIsSet(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	assert.Equal(t, "Grant 'GOOGLE_API_KEY'? [y/n/a/d/?]: ", formatConfirmPrompt("Grant 'GOOGLE_API_KEY'?"))
+}
+
 func TestStyleConfirmPromptPreservesGrantPromptText(t *testing.T) {
 	plain := "Grant 'GOOGLE_API_KEY'? [y/n/a/d/?]: "
 

--- a/cmd/prompt_style_test.go
+++ b/cmd/prompt_style_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStyleConfirmPromptPreservesGrantPromptText(t *testing.T) {
+	plain := "Grant 'GOOGLE_API_KEY'? [y/n/a/d/?]: "
+
+	styled := styleConfirmPrompt("Grant 'GOOGLE_API_KEY'?")
+
+	assert.Equal(t, plain, stripANSI(styled))
+	assert.Contains(t, styled, "\x1b[")
+	assert.Contains(t, styled, "GOOGLE_API_KEY")
+	assert.Contains(t, styled, "[y/n/a/d/?]")
+}
+
+func TestStyleConfirmPromptPreservesGenericPromptText(t *testing.T) {
+	plain := "Prompt 1? [y/n/a/d/?]: "
+
+	styled := styleConfirmPrompt("Prompt 1?")
+
+	assert.Equal(t, plain, stripANSI(styled))
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -153,7 +153,7 @@ func printLeases(leases []ipc.Lease, children map[string][]ipc.Lease) {
 		}
 	}
 	w.Flush()
-	fmt.Fprint(os.Stdout, styleStatusOutput(output.String()))
+	fmt.Fprint(os.Stdout, formatStatusOutput(output.String()))
 }
 
 func init() {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"sort"
@@ -118,7 +119,8 @@ var statusCmd = &cobra.Command{
 }
 
 func printLeases(leases []ipc.Lease, children map[string][]ipc.Lease) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	var output bytes.Buffer
+	w := tabwriter.NewWriter(&output, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "VARIABLE\tSOURCE\tDESTINATION\tEXPIRES IN")
 
 	for _, lease := range leases {
@@ -151,6 +153,7 @@ func printLeases(leases []ipc.Lease, children map[string][]ipc.Lease) {
 		}
 	}
 	w.Flush()
+	fmt.Fprint(os.Stdout, styleStatusOutput(output.String()))
 }
 
 func init() {

--- a/cmd/status_style.go
+++ b/cmd/status_style.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"regexp"
 	"strings"
 
@@ -47,6 +48,14 @@ var (
 	statusDurationPattern     = regexp.MustCompile(`\b\d+(?:h|m|s)(?:\d+(?:h|m|s))*\b`)
 	statusDurationPartPattern = regexp.MustCompile(`(\d+)([hms])`)
 )
+
+func formatStatusOutput(output string) string {
+	if !colorsEnabled(os.Stdout) {
+		return output
+	}
+
+	return styleStatusOutput(output)
+}
 
 func styleStatusOutput(output string) string {
 	if output == "" {

--- a/cmd/status_style.go
+++ b/cmd/status_style.go
@@ -1,0 +1,273 @@
+package cmd
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss/v2"
+)
+
+var (
+	statusHeaderStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#7dd3fc")).
+				Bold(true).
+				Underline(true)
+	statusTreeStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#34d399")).
+			Bold(true)
+	statusVariableStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#94a3b8"))
+	statusPlaceholderVariableStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("#38bdf8")).
+					Bold(true)
+	statusSourceSchemeStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#38bdf8")).
+				Bold(true)
+	statusSourceSeparatorStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("#64748b"))
+	statusSourcePathStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#64748b"))
+	statusSourceParentStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#94a3b8"))
+	statusSourceNameStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#f8fafc"))
+	statusPathDirStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#64748b"))
+	statusPathFileStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#e2e8f0")).
+				Bold(true)
+	statusDurationNumberStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("#94a3b8"))
+	statusDurationUnitStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#64748b"))
+)
+
+var (
+	statusAbsolutePathPattern = regexp.MustCompile(`/(?:[^/\s]+/)*[^/\s]+`)
+	statusDurationPattern     = regexp.MustCompile(`\b\d+(?:h|m|s)(?:\d+(?:h|m|s))*\b`)
+	statusDurationPartPattern = regexp.MustCompile(`(\d+)([hms])`)
+)
+
+func styleStatusOutput(output string) string {
+	if output == "" {
+		return output
+	}
+
+	lines := strings.SplitAfter(output, "\n")
+	for i, line := range lines {
+		lineEnding := ""
+		text := line
+		if strings.HasSuffix(line, "\n") {
+			lineEnding = "\n"
+			text = strings.TrimSuffix(line, "\n")
+		}
+
+		if strings.HasPrefix(text, "VARIABLE") {
+			text = styleStatusHeader(text)
+		} else {
+			text = styleStatusLine(text)
+		}
+
+		lines[i] = text + lineEnding
+	}
+
+	return strings.Join(lines, "")
+}
+
+func styleStatusHeader(line string) string {
+	for _, header := range []string{"VARIABLE", "SOURCE", "DESTINATION", "EXPIRES IN"} {
+		line = strings.Replace(line, header, statusHeaderStyle.Render(header), 1)
+	}
+	return line
+}
+
+func styleStatusLine(line string) string {
+	line = styleStatusDurations(line)
+
+	destinationStart := firstStatusDestinationPathStart(line)
+	if destinationStart >= 0 {
+		line = styleStatusSource(line[:destinationStart]) + styleStatusPaths(line[destinationStart:])
+	} else {
+		line = styleStatusSource(line)
+	}
+
+	line = styleStatusVariableName(line)
+	line = styleStatusTreeSymbols(line)
+	return line
+}
+
+func styleStatusTreeSymbols(line string) string {
+	for _, symbol := range []string{"├─", "└─", "│"} {
+		line = strings.ReplaceAll(line, symbol, statusTreeStyle.Render(symbol))
+	}
+	return line
+}
+
+func styleStatusVariableName(line string) string {
+	if start := strings.Index(line, "├─ "); start >= 0 {
+		return styleStatusVariableNameAt(line, start+len("├─ "))
+	}
+	if start := strings.Index(line, "└─ "); start >= 0 {
+		return styleStatusVariableNameAt(line, start+len("└─ "))
+	}
+
+	start := 0
+	for start < len(line) && line[start] == ' ' {
+		start++
+	}
+	return styleStatusVariableNameAt(line, start)
+}
+
+func styleStatusVariableNameAt(line string, start int) string {
+	if start >= len(line) {
+		return line
+	}
+
+	end := start
+	for end < len(line) && line[end] != ' ' && line[end] != '\t' {
+		end++
+	}
+	if end == start {
+		return line
+	}
+
+	variable := line[start:end]
+	if variable == "<exploded>" {
+		return line[:start] + statusPlaceholderVariableStyle.Render(variable) + line[end:]
+	}
+
+	return line[:start] + statusVariableStyle.Render(variable) + line[end:]
+}
+
+func styleStatusSource(line string) string {
+	schemeEnd := strings.Index(line, "://")
+	if schemeEnd < 0 {
+		return line
+	}
+
+	schemeStart := schemeEnd
+	for schemeStart > 0 && isStatusSchemeCharacter(line[schemeStart-1]) {
+		schemeStart--
+	}
+
+	sourceEnd := len(line)
+	for sourceEnd > schemeEnd+3 && line[sourceEnd-1] == ' ' {
+		sourceEnd--
+	}
+
+	source := line[schemeStart:sourceEnd]
+	padding := line[sourceEnd:]
+	pathStart := schemeEnd - schemeStart + len("://")
+
+	var styled strings.Builder
+	styled.WriteString(line[:schemeStart])
+	styled.WriteString(statusSourceSchemeStyle.Render(source[:schemeEnd-schemeStart]))
+	styled.WriteString(statusSourceSeparatorStyle.Render(source[schemeEnd-schemeStart : pathStart]))
+	styled.WriteString(styleStatusSourcePath(source[pathStart:]))
+	styled.WriteString(padding)
+	return styled.String()
+}
+
+func styleStatusSourcePath(path string) string {
+	if path == "" {
+		return path
+	}
+
+	parts := strings.Split(path, "/")
+	var styled strings.Builder
+	for i, part := range parts {
+		if part != "" {
+			styled.WriteString(styleStatusSourcePathPart(part, i, len(parts)))
+		}
+		if i < len(parts)-1 {
+			styled.WriteString(statusSourceSeparatorStyle.Render("/"))
+		}
+	}
+	return styled.String()
+}
+
+func styleStatusSourcePathPart(part string, index, count int) string {
+	switch index {
+	case count - 1:
+		return statusSourceNameStyle.Render(part)
+	case count - 2:
+		return statusSourceParentStyle.Render(part)
+	default:
+		return statusSourcePathStyle.Render(part)
+	}
+}
+
+func isStatusSchemeCharacter(b byte) bool {
+	return (b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') ||
+		b == '+' || b == '-' || b == '.'
+}
+
+func styleStatusPaths(line string) string {
+	matches := statusAbsolutePathPattern.FindAllStringIndex(line, -1)
+	if len(matches) == 0 {
+		return line
+	}
+
+	var styled strings.Builder
+	last := 0
+	for _, match := range matches {
+		start, end := match[0], match[1]
+		path := line[start:end]
+
+		styled.WriteString(line[last:start])
+		if isStatusDestinationPathStart(line, start) {
+			styled.WriteString(styleStatusPath(path))
+		} else {
+			styled.WriteString(path)
+		}
+		last = end
+	}
+	styled.WriteString(line[last:])
+	return styled.String()
+}
+
+func firstStatusDestinationPathStart(line string) int {
+	matches := statusAbsolutePathPattern.FindAllStringIndex(line, -1)
+	for _, match := range matches {
+		if isStatusDestinationPathStart(line, match[0]) {
+			return match[0]
+		}
+	}
+	return -1
+}
+
+func isStatusDestinationPathStart(line string, start int) bool {
+	if start == 0 {
+		return true
+	}
+
+	previous := line[start-1]
+	return previous == ' ' || previous == '\t'
+}
+
+func styleStatusPath(path string) string {
+	lastSlash := strings.LastIndex(path, "/")
+	if lastSlash < 0 || lastSlash == len(path)-1 {
+		return path
+	}
+
+	dir := path[:lastSlash+1]
+	file := path[lastSlash+1:]
+	return statusPathDirStyle.Render(dir) + statusPathFileStyle.Render(file)
+}
+
+func styleStatusDurations(line string) string {
+	return statusDurationPattern.ReplaceAllStringFunc(line, func(duration string) string {
+		return statusDurationPartPattern.ReplaceAllStringFunc(duration, func(part string) string {
+			matches := statusDurationPartPattern.FindStringSubmatch(part)
+			if len(matches) != 3 {
+				return part
+			}
+
+			return statusDurationNumberStyle.Render(matches[1]) +
+				statusDurationUnitStyle.Render(matches[2])
+		})
+	})
+}

--- a/cmd/status_style_test.go
+++ b/cmd/status_style_test.go
@@ -11,6 +11,14 @@ func stripANSI(s string) string {
 	return ansi.Strip(s)
 }
 
+func TestFormatStatusOutputPreservesPlainTextWhenNoColorIsSet(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	plain := "VARIABLE   SOURCE   DESTINATION       EXPIRES IN\n" +
+		"<file>     source   /Users/mbl/.env   59m33s\n"
+
+	assert.Equal(t, plain, formatStatusOutput(plain))
+}
+
 func TestStyleStatusOutputPreservesTextLayout(t *testing.T) {
 	plain := "VARIABLE           SOURCE                             DESTINATION       EXPIRES IN\n" +
 		"<exploded>         op+file://container_env.json      /Users/mbl/.env   59m33s\n" +

--- a/cmd/status_style_test.go
+++ b/cmd/status_style_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+)
+
+func stripANSI(s string) string {
+	return ansi.Strip(s)
+}
+
+func TestStyleStatusOutputPreservesTextLayout(t *testing.T) {
+	plain := "VARIABLE           SOURCE                             DESTINATION       EXPIRES IN\n" +
+		"<exploded>         op+file://container_env.json      /Users/mbl/.env   59m33s\n" +
+		" ├─ ORY_API_URL                                       /Users/mbl/.env   14h30m5s\n" +
+		" └─ ORY_SCHEMA_ID                                     /Users/mbl/.env   59m33s\n"
+
+	styled := styleStatusOutput(plain)
+
+	assert.Equal(t, plain, stripANSI(styled))
+	assert.Contains(t, styled, "\x1b[")
+}
+
+func TestStyleStatusOutputStylesRequestedSegments(t *testing.T) {
+	plain := "VARIABLE   SOURCE                                  DESTINATION       EXPIRES IN\n" +
+		"<file>     op://Private/Openrouter/Crush key      /Users/mbl/.env   14h30m5s\n" +
+		" └─ CHILD                                          /Users/mbl/.env   59m33s\n"
+
+	styled := styleStatusOutput(plain)
+
+	stripped := stripANSI(styled)
+	assert.Contains(t, stripped, "VARIABLE")
+	assert.Contains(t, stripped, "<file>")
+	assert.Contains(t, stripped, "CHILD")
+	assert.Contains(t, stripped, "op://Private/Openrouter/Crush key")
+	assert.Contains(t, stripped, "└─")
+	assert.Contains(t, stripped, "/Users/mbl/")
+	assert.Contains(t, stripped, ".env")
+	assert.Contains(t, stripped, "14h30m5s")
+	assert.Contains(t, styled, "14")
+	assert.Contains(t, styled, "h")
+	assert.Contains(t, styled, "30")
+	assert.Contains(t, styled, "m")
+	assert.Contains(t, styled, "5")
+	assert.Contains(t, styled, "s")
+	assert.Equal(t, plain, stripped)
+}
+
+func TestStyleStatusOutputStylesExplodedPlaceholder(t *testing.T) {
+	plain := "VARIABLE     SOURCE          DESTINATION       EXPIRES IN\n" +
+		"<exploded>   source          /Users/mbl/.env   59m33s\n"
+
+	styled := styleStatusOutput(plain)
+
+	assert.Equal(t, plain, stripANSI(styled))
+	assert.Contains(t, styled, "<exploded>")
+	assert.Contains(t, styled, "\x1b[1;38;2;56;189;248m<exploded>")
+}
+
+func TestStyleStatusOutputDoesNotTreatSourceSchemeSlashesAsPath(t *testing.T) {
+	plain := "VARIABLE     SOURCE                                              DESTINATION       EXPIRES IN\n" +
+		"<exploded>   op+file://app-iac container env/container_env.json   /Users/mbl/.env   59m33s\n"
+
+	styled := styleStatusOutput(plain)
+
+	assert.Equal(t, plain, stripANSI(styled))
+	assert.Contains(t, styled, "op+file")
+	assert.Contains(t, styled, "://")
+}

--- a/go.mod
+++ b/go.mod
@@ -5,18 +5,19 @@ go 1.24.6
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/charmbracelet/fang v0.4.3
+	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3.0.20250917201909-41ff0bf215ea
 	github.com/gen2brain/beeep v0.11.1
 	github.com/lmittmann/tint v1.1.2
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
+	golang.org/x/sync v0.17.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	git.sr.ht/~jackmordaunt/go-toast v1.1.2 // indirect
 	github.com/charmbracelet/colorprofile v0.3.2 // indirect
-	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3.0.20250917201909-41ff0bf215ea // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20250915111650-81d4262876ef // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
@@ -47,7 +48,6 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/charmbracelet/fang v0.4.3
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3.0.20250917201909-41ff0bf215ea
+	github.com/charmbracelet/x/ansi v0.10.1
+	github.com/charmbracelet/x/term v0.2.1
 	github.com/gen2brain/beeep v0.11.1
 	github.com/lmittmann/tint v1.1.2
 	github.com/spf13/cobra v1.10.1
@@ -19,10 +21,8 @@ require (
 	git.sr.ht/~jackmordaunt/go-toast v1.1.2 // indirect
 	github.com/charmbracelet/colorprofile v0.3.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20250915111650-81d4262876ef // indirect
-	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250603201427-c31516f43444 // indirect
-	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
## Summary
- Add Lip Gloss styling for `status` output while preserving the existing table layout
- Color status headers, tree glyphs, source paths, destination filenames, variable names, and durations
- Add styled interactive grant prompts with clearer secret-name emphasis

## Testing
- `mise run test`
- `mise run lint`
