### PR TITLE
refactor: clean up post-deepening seams

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -27,20 +26,20 @@ It looks for variable assignments with 1Password secret URIs (e.g., export API_K
 
 		if len(args) > 0 {
 			filename = args[0]
-			input, err = ioutil.ReadFile(filename)
+			input, err = os.ReadFile(filename)
 			if err != nil {
 				return fmt.Errorf("could not read file %s: %w", filename, err)
 			}
 		} else {
 			if _, err := os.Stat(".envrc"); err == nil {
 				filename = ".envrc"
-				input, err = ioutil.ReadFile(filename)
+				input, err = os.ReadFile(filename)
 				if err != nil {
 					return fmt.Errorf("could not read .envrc: %w", err)
 				}
 			} else if _, err := os.Stat(".env"); err == nil {
 				filename = ".env"
-				input, err = ioutil.ReadFile(filename)
+				input, err = os.ReadFile(filename)
 				if err != nil {
 					return fmt.Errorf("could not read .env: %w", err)
 				}

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ import (
 
 func TestConvertCmd(t *testing.T) {
 	// Create a temporary directory for our test files
-	tmpDir, err := ioutil.TempDir("", "env-lease-test")
+	tmpDir, err := os.MkdirTemp("", "env-lease-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
@@ -28,7 +27,7 @@ export   EXTRA_VAR=op://vault/item3/field3
 INVALID_LINE
 `
 	envrcPath := filepath.Join(tmpDir, ".envrc")
-	err = ioutil.WriteFile(envrcPath, []byte(envrcContent), 0644)
+	err = os.WriteFile(envrcPath, []byte(envrcContent), 0644)
 	require.NoError(t, err)
 
 	// Test case 1: Read from .envrc in current directory
@@ -95,7 +94,7 @@ duration = "1h"
 	// Test case 3: No file found
 	t.Run("no file found", func(t *testing.T) {
 		// Change to a directory with no .env or .envrc
-		emptyDir, err := ioutil.TempDir("", "env-lease-empty")
+		emptyDir, err := os.MkdirTemp("", "env-lease-empty")
 		require.NoError(t, err)
 		defer os.RemoveAll(emptyDir)
 

--- a/cmd/grant.go
+++ b/cmd/grant.go
@@ -78,8 +78,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var shellMode bool
-
 var grantCmd = &cobra.Command{
 	Use:   "grant",
 	Short: "Grant all leases defined in env-lease.toml.",
@@ -127,12 +125,7 @@ This can be overridden with the --destination-outside-root flag.`,
 				"Please run 'eval $(env-lease grant)' without the interactive flag.")
 		}
 
-		for _, l := range leaseSet.Leases {
-			if l.LeaseType == "shell" {
-				shellMode = true
-				break
-			}
-		}
+		shellMode := leaseSet.HasShellLease()
 
 		client := ensureDaemonClient()
 

--- a/cmd/grant_test.go
+++ b/cmd/grant_test.go
@@ -263,7 +263,6 @@ duration = "1m"
 
 func TestGrantPreflightDaemonNotRunning(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") == "1" {
-		shellMode = false
 		resetConfirmState()
 		_ = os.Unsetenv("ENV_LEASE_TEST")
 

--- a/cmd/revoke.go
+++ b/cmd/revoke.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mblarsen/env-lease/internal/config"
 	"github.com/mblarsen/env-lease/internal/ipc"
+	"github.com/mblarsen/env-lease/internal/lease"
 	"github.com/spf13/cobra"
 )
 
@@ -60,8 +61,8 @@ var revokeCmd = &cobra.Command{
 
 			// Second pass: separate actual parents from normal leases
 			for _, l := range potentialParentsAndNormalLeases {
-				uniqueID := l.Source + "->" + l.Destination
-				if _, isParent := childrenOfParent[uniqueID]; isParent {
+				parentID := lease.ParentIdentity(l.Source, l.Destination)
+				if _, isParent := childrenOfParent[parentID]; isParent {
 					parents = append(parents, l)
 				} else {
 					normalLeases = append(normalLeases, l)
@@ -70,8 +71,8 @@ var revokeCmd = &cobra.Command{
 
 			// Process parents and their children
 			for _, p := range parents {
-				uniqueID := p.Source + "->" + p.Destination
-				children := childrenOfParent[uniqueID]
+				parentID := lease.ParentIdentity(p.Source, p.Destination)
+				children := childrenOfParent[parentID]
 				sort.Slice(children, func(i, j int) bool {
 					return children[i].Variable < children[j].Variable
 				})

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mblarsen/env-lease/internal/config"
 	"github.com/mblarsen/env-lease/internal/ipc"
+	"github.com/mblarsen/env-lease/internal/lease"
 	"github.com/spf13/cobra"
 )
 
@@ -41,15 +42,7 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
-		// The status command doesn't need to load the config, it just needs the path
-		// to filter leases. So we don't call config.Load here. But if we did, it
-		// would look like this:
-		// localConfigFileFlag, _ := cmd.Flags().GetString("local-config")
-		// _, err = config.Load(absConfigFile, localConfigFileFlag)
-		// if err != nil {
-		// 	return err
-		// }
-
+		// Status filters daemon state by config path without loading the Config.
 		showAll, _ := cmd.Flags().GetBool("all")
 
 		// Group all leases hierarchically first
@@ -88,9 +81,9 @@ var statusCmd = &cobra.Command{
 		// Calculate other leases count, excluding parent leases from the count
 		if !showAll {
 			var allLeasesCount int
-			for _, lease := range allTopLevelLeases {
-				uniqueParentID := lease.Source + "->" + lease.Destination
-				if children, isParent := groupedLeases[uniqueParentID]; isParent {
+			for _, topLevel := range allTopLevelLeases {
+				parentID := lease.ParentIdentity(topLevel.Source, topLevel.Destination)
+				if children, isParent := groupedLeases[parentID]; isParent {
 					allLeasesCount += len(children)
 				} else {
 					allLeasesCount++
@@ -98,9 +91,9 @@ var statusCmd = &cobra.Command{
 			}
 
 			var displayedLeasesCount int
-			for _, lease := range leasesToDisplay {
-				uniqueParentID := lease.Source + "->" + lease.Destination
-				if children, isParent := groupedLeases[uniqueParentID]; isParent {
+			for _, displayed := range leasesToDisplay {
+				parentID := lease.ParentIdentity(displayed.Source, displayed.Destination)
+				if children, isParent := groupedLeases[parentID]; isParent {
 					displayedLeasesCount += len(children)
 				} else {
 					displayedLeasesCount++
@@ -123,21 +116,20 @@ func printLeases(leases []ipc.Lease, children map[string][]ipc.Lease) {
 	w := tabwriter.NewWriter(&output, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "VARIABLE\tSOURCE\tDESTINATION\tEXPIRES IN")
 
-	for _, lease := range leases {
-		expiresIn := time.Until(lease.ExpiresAt).Round(time.Second)
-		variable := lease.Variable
+	for _, displayed := range leases {
+		expiresIn := time.Until(displayed.ExpiresAt).Round(time.Second)
+		variable := displayed.Variable
 		if variable == "" {
-			if lease.LeaseType == "file" {
+			if displayed.LeaseType == "file" {
 				variable = "<file>"
 			} else {
 				variable = "<exploded>"
 			}
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", variable, lease.Source, lease.Destination, expiresIn)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", variable, displayed.Source, displayed.Destination, expiresIn)
 
-		// Create a unique ID for the parent to find children
-		uniqueParentID := lease.Source + "->" + lease.Destination
-		if childLeases, ok := children[uniqueParentID]; ok {
+		parentID := lease.ParentIdentity(displayed.Source, displayed.Destination)
+		if childLeases, ok := children[parentID]; ok {
 			// Sort children by variable name
 			sort.Slice(childLeases, func(i, j int) bool {
 				return childLeases[i].Variable < childLeases[j].Variable

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"time"
 
 	"os"
 
@@ -21,23 +20,19 @@ type Config struct {
 
 // Lease represents a single lease block in the config.
 type Lease struct {
-	Provider      string     `toml:"provider"`
-	Source        string     `toml:"source"`
-	Destination   string     `toml:"destination"`
-	Duration      string     `toml:"duration"`
-	LeaseType     string     `toml:"lease_type"`
-	Variable      string     `toml:"variable"`
-	Format        string     `toml:"format"`
-	Transform     []string   `toml:"transform"`
-	FileMode      string     `toml:"file_mode"`
-	OpAccount     string     `toml:"op_account" json:"op_account,omitempty"`
-	ExpiresAt     time.Time  `toml:"-" json:"expires_at"`
-	OrphanedSince *time.Time `toml:"-" json:"orphaned_since,omitempty"`
-	ConfigFile    string     `toml:"-" json:"config_file"`
-	ParentSource  string     `toml:"-" json:"parent_source,omitempty"`
+	Provider    string   `toml:"provider"`
+	Source      string   `toml:"source"`
+	Destination string   `toml:"destination"`
+	Duration    string   `toml:"duration"`
+	LeaseType   string   `toml:"lease_type"`
+	Variable    string   `toml:"variable"`
+	Format      string   `toml:"format"`
+	Transform   []string `toml:"transform"`
+	FileMode    string   `toml:"file_mode"`
+	OpAccount   string   `toml:"op_account"`
 }
 
-// Load reads a TOML file from the given path, validates it, and returns a Config struct.
+// Load reads and merges raw TOML config files without applying Lease semantics.
 func Load(path, localPath string) (*Config, error) {
 	return loadAndMerge(path, localPath, 0)
 }
@@ -51,16 +46,11 @@ func loadAndMerge(path, localPath string, depth int) (*Config, error) {
 		Lease []Lease `toml:"lease"`
 	}
 
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return nil, fmt.Errorf("could not get absolute path for config: %w", err)
-	}
-
 	expandedPath, err := fileutil.ExpandPath(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not expand config path: %w", err)
 	}
-	absPath, err = filepath.Abs(expandedPath)
+	absPath, err := filepath.Abs(expandedPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not get absolute path for config: %w", err)
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -31,8 +31,7 @@ func (m *mockClock) Advance(d time.Duration) {
 	m.now = m.now.Add(d)
 }
 
-// TODO: This is a placeholder test. A real test would need to capture stdout.
-func TestDaemon_Run(t *testing.T) {
+func TestDaemon_RunStopsWhenContextIsCancelled(t *testing.T) {
 	state := NewState()
 	clock := &mockClock{now: time.Now()}
 	revoker := &mockRevoker{}

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -30,6 +30,16 @@ type Set struct {
 	Leases     []Lease
 }
 
+// HasShellLease reports whether the set contains at least one shell Lease.
+func (s Set) HasShellLease() bool {
+	for _, l := range s.Leases {
+		if l.LeaseType == TypeShell {
+			return true
+		}
+	}
+	return false
+}
+
 // Lease is the normalized runtime shape used by grant and daemon logic.
 type Lease struct {
 	Provider       string     `json:"provider,omitempty"`
@@ -109,10 +119,7 @@ func normalizeOne(root, configFile string, raw config.Lease) (Lease, error) {
 		Transform:      append([]string(nil), raw.Transform...),
 		FileMode:       raw.FileMode,
 		OpAccount:      raw.OpAccount,
-		ExpiresAt:      raw.ExpiresAt,
-		OrphanedSince:  raw.OrphanedSince,
 		ConfigFile:     configFile,
-		ParentSource:   raw.ParentSource,
 	}
 
 	if l.Source == "" {

--- a/internal/provider/doc.go
+++ b/internal/provider/doc.go
@@ -1,2 +1,2 @@
-// Package provider defines the interface for secret providers and implementations for backends like 1Password.
+// Package provider defines lower-level adapters that fetch Secrets from external Providers.
 package provider


### PR DESCRIPTION
## Summary
- remove stale raw Config runtime fields now owned by normalized Leases
- reuse Lease parent identity helpers in status/revoke flows
- remove grant shell-mode global state and refresh stale cleanup docs/usages

## Validation
- `gofmt -w cmd internal`
- `mise run lint`
- `mise run test`
- `git diff --check`
