### PR TITLE
refactor: deepen provider adapter seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,11 +29,11 @@ The reversible act of applying or removing a Secret at a Destination during Gran
 _Avoid_: file write, shell output, destination handling
 
 **Provider**:
-The external secret store or CLI that resolves a Secret source into Secret material.
+The external secret store or CLI that resolves a Secret source into Secret material through a lower-level Adapter.
 _Avoid_: backend, vault, service
 
 **Secret Lookup**:
-The act of resolving an approved Lease's Secret source through a Provider before Grant materializes it.
+The act of resolving an approved Lease's Secret source through a selected Provider/account Adapter before Grant materializes it.
 _Avoid_: provider fetch, backend lookup, source read
 
 **Secret Transformation**:
@@ -61,7 +61,7 @@ _Avoid_: manifest, spec, settings
 - A **Config** declares zero or more **Leases**.
 - A **Lease** identifies exactly one **Secret** source and one **Destination**.
 - **Destination Mutation** applies or removes a **Secret** at a **Destination**.
-- A **Provider** performs **Secret Lookup** for an approved **Lease**.
+- A **Provider** Adapter performs **Secret Lookup** for an approved **Lease**.
 - A **Grant** runs a **Grant Workflow**.
 - The **Grant Workflow** uses **Secret Lookup** before **Secret Transformation**.
 - **Secret Transformation** produces one **Secret** or an exploded set of Secrets for the **Grant Workflow** to materialize at their **Destination**.

--- a/docs/provider_support.md
+++ b/docs/provider_support.md
@@ -1,20 +1,39 @@
 # Provider Support
 
-This document outlines the implementation and testing strategy for various secret providers.
+Provider support is split across two seams:
 
-### Provider Implementation & Testing Comparison
+- `internal/provider` is the lower-level **Adapter** seam. It selects a Provider adapter from a normalized provider name, records which URI schemes the adapter can batch, and shells out to the Provider CLI.
+- `internal/secretlookup` owns **Secret Lookup** orchestration. It chooses Provider/account groups before crossing the adapter seam, deduplicates singleton sources, and keeps 1Password-specific batching decisions out of `cmd` and `grantflow`.
 
-All providers can be implemented similarly to the `OnePasswordCLI` by creating a new struct that implements the `SecretProvider` interface and shells out to the respective CLI. The ease of getting started and testing varies:
+Today the built-in registry supports 1Password (`provider = "1password"`, aliases `op` and `onepassword`). The 1Password adapter batches canonical `op://` sources through `op inject`; `op+file://` remains a 1Password adapter concern and is fetched as a deduplicated singleton because it must first resolve file metadata.
+
+## Adding a Provider
+
+Add one minimal adapter at a time:
+
+1. Implement `provider.SecretProvider` in `internal/provider/<name>.go`.
+2. Register an `AdapterSpec` in `provider.DefaultRegistry()` with:
+   - canonical provider name and optional aliases,
+   - URI schemes that are safe to fetch through `FetchLeases`,
+   - an account-scoped constructor.
+3. Keep account selection and cross-lease orchestration in `secretlookup`; keep CLI-specific command shape, URI normalization, and batching mechanics in the adapter.
+4. Add registry tests for unknown provider errors, selection, and scheme batching. Add adapter tests for CLI command behaviour.
+
+Avoid adding Provider-specific branches in `cmd` or `grantflow`. If adding a Provider requires those callers to know a URI scheme or CLI detail, deepen the `provider` registry or `secretlookup` plan instead.
+
+## Provider Implementation & Testing Comparison
+
+All providers can be implemented similarly to `OnePasswordCLI`: create a struct that implements `SecretProvider`, shell out to the respective CLI, and register its schemes. The ease of getting started and testing varies:
 
 | Provider | CLI Tool | Local Testing Approach | Getting Started Difficulty |
 | :--- | :--- | :--- | :--- |
 | **HashiCorp Vault** | `vault` | Official dev mode (`vault server -dev`) | **Easy** |
 | **AWS Secrets Manager** | `aws` | `localstack` (local AWS cloud) | **Medium** |
-| **Google Secret Manager**| `gcloud` | Official emulator | **Medium** |
+| **Google Secret Manager** | `gcloud` | Official emulator | **Medium** |
 | **Infisical** | `infisical` | Self-hosted Docker container | **Medium** |
 | **Bitwarden** | `bw` | `vaultwarden` (self-hosted) | **Medium** |
 | **Azure Key Vault** | `az` | No official emulator; requires mocking or a live resource | **Hard** |
 
-### Authentication
+## Authentication
 
-The tool can maintain its zero-config approach by deferring authentication to the underlying CLI tools, similar to the existing 1Password integration. All the listed provider CLIs manage their own authentication state, typically through a `login` command or standard environment variables (`VAULT_TOKEN`, `AWS_ACCESS_KEY_ID`, `BW_SESSION`, etc.). `env-lease` simply needs to execute the CLI command, assuming the user has already authenticated it.
+The tool can maintain its zero-config approach by deferring authentication to the underlying CLI tools, similar to the existing 1Password integration. Provider CLIs manage their own authentication state, typically through a login command or standard environment variables (`VAULT_TOKEN`, `AWS_ACCESS_KEY_ID`, `BW_SESSION`, etc.). `env-lease` executes the CLI command assuming the user has already authenticated it.

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -54,11 +54,12 @@ func NewRegistry(specs ...AdapterSpec) (*Registry, error) {
 			batchableSchemes: normalizeSchemes(spec.BatchableSchemes),
 			new:              spec.New,
 		}
-		for _, name := range append([]string{spec.Name}, spec.Aliases...) {
-			key := NormalizeName(name)
-			if key == "" {
+		names := append([]string{spec.Name}, spec.Aliases...)
+		for i, name := range names {
+			if i > 0 && strings.TrimSpace(name) == "" {
 				continue
 			}
+			key := NormalizeName(name)
 			if existing, ok := r.adapters[key]; ok {
 				return nil, fmt.Errorf("provider registry: provider %q already registered as %q", key, existing.name)
 			}

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -1,0 +1,158 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// DefaultProviderName is the provider used for leases that omit provider.
+const DefaultProviderName = "1password"
+
+// AdapterFactory creates a Provider adapter for one normalized account scope.
+type AdapterFactory func(account string) (SecretProvider, error)
+
+// AdapterSpec describes one Provider implementation and the URI schemes whose
+// lookup behaviour belongs to that adapter.
+type AdapterSpec struct {
+	// Name is the canonical provider name used in lease configuration.
+	Name string
+	// Aliases are additional provider names accepted for this implementation.
+	Aliases []string
+	// BatchableSchemes are source URI schemes this adapter can fetch in a single
+	// FetchLeases call. Other schemes are fetched as deduplicated singletons.
+	BatchableSchemes []string
+	// New constructs the account-scoped adapter.
+	New AdapterFactory
+}
+
+type adapterRegistration struct {
+	name             string
+	batchableSchemes map[string]struct{}
+	new              AdapterFactory
+}
+
+// Registry localizes Provider selection and per-provider URI capabilities.
+type Registry struct {
+	adapters map[string]adapterRegistration
+}
+
+// NewRegistry builds a Registry from adapter specs.
+func NewRegistry(specs ...AdapterSpec) (*Registry, error) {
+	r := &Registry{adapters: make(map[string]adapterRegistration)}
+	for _, spec := range specs {
+		if spec.Name == "" {
+			return nil, fmt.Errorf("provider registry: missing adapter name")
+		}
+		if spec.New == nil {
+			return nil, fmt.Errorf("provider registry: missing adapter factory for %q", spec.Name)
+		}
+
+		canonical := NormalizeName(spec.Name)
+		registration := adapterRegistration{
+			name:             canonical,
+			batchableSchemes: normalizeSchemes(spec.BatchableSchemes),
+			new:              spec.New,
+		}
+		for _, name := range append([]string{spec.Name}, spec.Aliases...) {
+			key := NormalizeName(name)
+			if key == "" {
+				continue
+			}
+			if existing, ok := r.adapters[key]; ok {
+				return nil, fmt.Errorf("provider registry: provider %q already registered as %q", key, existing.name)
+			}
+			r.adapters[key] = registration
+		}
+	}
+	return r, nil
+}
+
+// DefaultRegistry returns the built-in Provider adapters.
+func DefaultRegistry() *Registry {
+	factory := func(account string) (SecretProvider, error) {
+		return &OnePasswordCLI{Account: account}, nil
+	}
+	if os.Getenv("ENV_LEASE_TEST") == "1" {
+		factory = func(account string) (SecretProvider, error) {
+			return &MockProvider{}, nil
+		}
+	}
+
+	r, err := NewRegistry(AdapterSpec{
+		Name:             DefaultProviderName,
+		Aliases:          []string{"op", "onepassword"},
+		BatchableSchemes: []string{"op"},
+		New:              factory,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// NewAdapter creates the adapter registered for providerName.
+func (r *Registry) NewAdapter(providerName, account string) (SecretProvider, error) {
+	registration, err := r.registration(providerName)
+	if err != nil {
+		return nil, err
+	}
+	return registration.new(account)
+}
+
+// CanonicalName returns the normalized canonical provider name.
+func (r *Registry) CanonicalName(providerName string) (string, error) {
+	registration, err := r.registration(providerName)
+	if err != nil {
+		return "", err
+	}
+	return registration.name, nil
+}
+
+// CanBatch reports whether providerName owns batched lookup for sourceURI's scheme.
+func (r *Registry) CanBatch(providerName, sourceURI string) bool {
+	registration, err := r.registration(providerName)
+	if err != nil {
+		return false
+	}
+	_, ok := registration.batchableSchemes[SourceScheme(sourceURI)]
+	return ok
+}
+
+// NormalizeName normalizes a lease provider name for selection.
+func NormalizeName(providerName string) string {
+	name := strings.ToLower(strings.TrimSpace(providerName))
+	if name == "" {
+		return DefaultProviderName
+	}
+	return name
+}
+
+// SourceScheme returns the normalized URI scheme for a lease source.
+func SourceScheme(sourceURI string) string {
+	before, _, ok := strings.Cut(strings.TrimSpace(sourceURI), "://")
+	if !ok {
+		return ""
+	}
+	return strings.ToLower(before)
+}
+
+func (r *Registry) registration(providerName string) (adapterRegistration, error) {
+	name := NormalizeName(providerName)
+	registration, ok := r.adapters[name]
+	if !ok {
+		return adapterRegistration{}, fmt.Errorf("unknown provider %q", providerName)
+	}
+	return registration, nil
+}
+
+func normalizeSchemes(schemes []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(schemes))
+	for _, scheme := range schemes {
+		scheme = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(scheme, "://")))
+		if scheme != "" {
+			out[scheme] = struct{}{}
+		}
+	}
+	return out
+}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -1,0 +1,86 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultRegistrySelectsOnePasswordAdapter(t *testing.T) {
+	t.Setenv("ENV_LEASE_TEST", "")
+
+	adapter, err := DefaultRegistry().NewAdapter("1password", "team-account")
+	if err != nil {
+		t.Fatalf("NewAdapter returned error: %v", err)
+	}
+
+	op, ok := adapter.(*OnePasswordCLI)
+	if !ok {
+		t.Fatalf("adapter type = %T, want *OnePasswordCLI", adapter)
+	}
+	if op.Account != "team-account" {
+		t.Fatalf("account = %q, want %q", op.Account, "team-account")
+	}
+}
+
+func TestDefaultRegistryNormalizesAliasesAndDefaultProvider(t *testing.T) {
+	t.Setenv("ENV_LEASE_TEST", "")
+	registry := DefaultRegistry()
+
+	for _, name := range []string{"", "1PASSWORD", " onepassword ", "op"} {
+		canonical, err := registry.CanonicalName(name)
+		if err != nil {
+			t.Fatalf("CanonicalName(%q) returned error: %v", name, err)
+		}
+		if canonical != "1password" {
+			t.Fatalf("CanonicalName(%q) = %q, want 1password", name, canonical)
+		}
+	}
+}
+
+func TestDefaultRegistryReportsUnknownProvider(t *testing.T) {
+	_, err := DefaultRegistry().NewAdapter("vault", "")
+	if err == nil {
+		t.Fatal("expected unknown provider error")
+	}
+	if !strings.Contains(err.Error(), `unknown provider "vault"`) {
+		t.Fatalf("error = %q, want unknown provider", err.Error())
+	}
+}
+
+func TestDefaultRegistryBatchPolicyIsSchemeSpecific(t *testing.T) {
+	registry := DefaultRegistry()
+
+	if !registry.CanBatch("1password", "op://vault/item/field") {
+		t.Fatal("expected op:// to be batchable for 1password")
+	}
+	if registry.CanBatch("1password", "op+file://item/file.json") {
+		t.Fatal("expected op+file:// to be fetched as singleton for 1password")
+	}
+	if registry.CanBatch("vault", "op://vault/item/field") {
+		t.Fatal("expected unknown providers to be non-batchable")
+	}
+}
+
+func TestNewRegistrySupportsAdditionalProviderWithoutLookupChanges(t *testing.T) {
+	registry, err := NewRegistry(AdapterSpec{
+		Name:             "vault",
+		BatchableSchemes: []string{"vault"},
+		New: func(account string) (SecretProvider, error) {
+			return &MockProvider{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry returned error: %v", err)
+	}
+
+	if !registry.CanBatch("vault", "vault://secret/data/app#token") {
+		t.Fatal("expected registered vault:// scheme to be batchable")
+	}
+	adapter, err := registry.NewAdapter("vault", "")
+	if err != nil {
+		t.Fatalf("NewAdapter returned error: %v", err)
+	}
+	if _, ok := adapter.(*MockProvider); !ok {
+		t.Fatalf("adapter type = %T, want *MockProvider", adapter)
+	}
+}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -61,6 +61,43 @@ func TestDefaultRegistryBatchPolicyIsSchemeSpecific(t *testing.T) {
 	}
 }
 
+func TestNewRegistrySkipsBlankAliases(t *testing.T) {
+	registry, err := NewRegistry(
+		AdapterSpec{
+			Name:             DefaultProviderName,
+			BatchableSchemes: []string{"op"},
+			New: func(account string) (SecretProvider, error) {
+				return &OnePasswordCLI{Account: account}, nil
+			},
+		},
+		AdapterSpec{
+			Name:    "vault",
+			Aliases: []string{"", "   "},
+			New: func(account string) (SecretProvider, error) {
+				return &MockProvider{}, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry returned error: %v", err)
+	}
+
+	canonical, err := registry.CanonicalName("")
+	if err != nil {
+		t.Fatalf("CanonicalName returned error: %v", err)
+	}
+	if canonical != DefaultProviderName {
+		t.Fatalf("CanonicalName(\"\") = %q, want %q", canonical, DefaultProviderName)
+	}
+	adapter, err := registry.NewAdapter("", "team-account")
+	if err != nil {
+		t.Fatalf("NewAdapter returned error: %v", err)
+	}
+	if _, ok := adapter.(*OnePasswordCLI); !ok {
+		t.Fatalf("adapter type = %T, want *OnePasswordCLI", adapter)
+	}
+}
+
 func TestNewRegistrySupportsAdditionalProviderWithoutLookupChanges(t *testing.T) {
 	registry, err := NewRegistry(AdapterSpec{
 		Name:             "vault",

--- a/internal/secretlookup/lookup.go
+++ b/internal/secretlookup/lookup.go
@@ -4,8 +4,6 @@ package secretlookup
 import (
 	"fmt"
 	"log/slog"
-	"os"
-	"strings"
 	"sync"
 
 	"github.com/mblarsen/env-lease/internal/lease"
@@ -51,9 +49,13 @@ func (s *Secrets) set(l lease.Lease, secret string) {
 // ProviderFactory creates Provider adapters for a normalized provider/account pair.
 type ProviderFactory func(providerName, account string) (provider.SecretProvider, error)
 
+// BatchPolicy reports whether providerName can batch sourceURI through FetchLeases.
+type BatchPolicy func(providerName, sourceURI string) bool
+
 // Lookup resolves Secret material for normalized Leases.
 type Lookup struct {
 	providerFactory ProviderFactory
+	canBatch        BatchPolicy
 }
 
 // New creates a Secret lookup Module with the default Provider adapter factory.
@@ -63,10 +65,19 @@ func New() *Lookup {
 
 // NewWithProviderFactory creates a Secret lookup Module with a custom Provider adapter factory.
 func NewWithProviderFactory(factory ProviderFactory) *Lookup {
+	return NewWithProviderFactoryAndBatchPolicy(factory, nil)
+}
+
+// NewWithProviderFactoryAndBatchPolicy creates a Secret lookup Module with a
+// custom Provider adapter factory and explicit provider URI batching policy.
+func NewWithProviderFactoryAndBatchPolicy(factory ProviderFactory, canBatch BatchPolicy) *Lookup {
 	if factory == nil {
 		factory = defaultProviderFactory
 	}
-	return &Lookup{providerFactory: factory}
+	if canBatch == nil {
+		canBatch = defaultBatchPolicy
+	}
+	return &Lookup{providerFactory: factory, canBatch: canBatch}
 }
 
 // Fetch resolves Secret material for leases using the default lookup Module.
@@ -74,16 +85,17 @@ func Fetch(leases []lease.Lease, opts Options) (Secrets, []Error, error) {
 	return New().Fetch(leases, opts)
 }
 
-// Fetch resolves Secret material for leases. op:// sources are batched by
-// Provider and account. Other sources are deduplicated by Provider, account, and
-// source URI, then fetched once and shared by matching Leases.
+// Fetch resolves Secret material for leases. Sources with Provider-registered
+// batchable schemes are batched by Provider and account. Other sources are
+// deduplicated by Provider, account, and source URI, then fetched once and
+// shared by matching Leases.
 func (lookup *Lookup) Fetch(leases []lease.Lease, opts Options) (Secrets, []Error, error) {
-	plan := buildPlan(leases)
+	plan := buildPlan(leases, lookup.canBatch)
 
 	slog.Debug("secret lookup: start",
 		"mode", opts.Mode,
 		"lease_count", len(leases),
-		"op_batches", len(plan.opBatches),
+		"batches", len(plan.batches),
 		"single_sources", len(plan.singletons))
 
 	secrets := Secrets{byKey: make(map[key]string, len(leases))}
@@ -92,7 +104,7 @@ func (lookup *Lookup) Fetch(leases []lease.Lease, opts Options) (Secrets, []Erro
 	var mu sync.Mutex
 	var group errgroup.Group
 
-	for _, batch := range plan.opBatches {
+	for _, batch := range plan.batches {
 		batch := batch
 		group.Go(func() error {
 			providerAdapter, err := lookup.providerFactory(batch.providerName, batch.account)
@@ -132,7 +144,7 @@ func (lookup *Lookup) Fetch(leases []lease.Lease, opts Options) (Secrets, []Erro
 			}
 			mu.Unlock()
 
-			slog.Debug("secret lookup: fetched op batch",
+			slog.Debug("secret lookup: fetched batch",
 				"mode", opts.Mode,
 				"provider", batch.providerName,
 				"account", batch.account,
@@ -141,7 +153,7 @@ func (lookup *Lookup) Fetch(leases []lease.Lease, opts Options) (Secrets, []Erro
 				"error_count", len(providerErrs))
 
 			if len(lookupErrs) > 0 && !opts.ContinueOnError {
-				return fmt.Errorf("secret lookup: failed op batch provider %s account %s", batch.providerName, batch.account)
+				return fmt.Errorf("secret lookup: failed batch provider %s account %s", batch.providerName, batch.account)
 			}
 			return nil
 		})
@@ -198,23 +210,19 @@ func (lookup *Lookup) Fetch(leases []lease.Lease, opts Options) (Secrets, []Erro
 }
 
 func defaultProviderFactory(providerName, account string) (provider.SecretProvider, error) {
-	switch providerName {
-	case "", "1password":
-		if os.Getenv("ENV_LEASE_TEST") == "1" {
-			return &provider.MockProvider{}, nil
-		}
-		return &provider.OnePasswordCLI{Account: account}, nil
-	default:
-		return nil, fmt.Errorf("unknown provider %q", providerName)
-	}
+	return provider.DefaultRegistry().NewAdapter(providerName, account)
+}
+
+func defaultBatchPolicy(providerName, sourceURI string) bool {
+	return provider.DefaultRegistry().CanBatch(providerName, sourceURI)
 }
 
 type plan struct {
-	opBatches  []opBatch
+	batches    []batch
 	singletons []sourceGroup
 }
 
-type opBatch struct {
+type batch struct {
 	providerName string
 	account      string
 	leases       []lease.Lease
@@ -240,24 +248,24 @@ type sourceKey struct {
 
 type key sourceKey
 
-func buildPlan(leases []lease.Lease) plan {
-	opByAccount := make(map[providerAccount]int)
+func buildPlan(leases []lease.Lease, canBatch BatchPolicy) plan {
+	batchesByAccount := make(map[providerAccount]int)
 	singletonsBySource := make(map[sourceKey]int)
 	plan := plan{}
 
 	for _, l := range leases {
-		if strings.HasPrefix(l.Source, "op://") {
+		if canBatch(l.Provider, l.Source) {
 			accountKey := providerAccount{providerName: l.Provider, account: l.OpAccount}
-			idx, ok := opByAccount[accountKey]
+			idx, ok := batchesByAccount[accountKey]
 			if !ok {
-				idx = len(plan.opBatches)
-				opByAccount[accountKey] = idx
-				plan.opBatches = append(plan.opBatches, opBatch{
+				idx = len(plan.batches)
+				batchesByAccount[accountKey] = idx
+				plan.batches = append(plan.batches, batch{
 					providerName: l.Provider,
 					account:      l.OpAccount,
 				})
 			}
-			plan.opBatches[idx].leases = append(plan.opBatches[idx].leases, l)
+			plan.batches[idx].leases = append(plan.batches[idx].leases, l)
 			continue
 		}
 

--- a/internal/secretlookup/lookup.go
+++ b/internal/secretlookup/lookup.go
@@ -52,10 +52,14 @@ type ProviderFactory func(providerName, account string) (provider.SecretProvider
 // BatchPolicy reports whether providerName can batch sourceURI through FetchLeases.
 type BatchPolicy func(providerName, sourceURI string) bool
 
+// ProviderNormalizer returns the canonical name used for Provider grouping and selection.
+type ProviderNormalizer func(providerName string) string
+
 // Lookup resolves Secret material for normalized Leases.
 type Lookup struct {
-	providerFactory ProviderFactory
-	canBatch        BatchPolicy
+	providerFactory   ProviderFactory
+	canBatch          BatchPolicy
+	normalizeProvider ProviderNormalizer
 }
 
 // New creates a Secret lookup Module with the default Provider adapter factory.
@@ -77,7 +81,7 @@ func NewWithProviderFactoryAndBatchPolicy(factory ProviderFactory, canBatch Batc
 	if canBatch == nil {
 		canBatch = defaultBatchPolicy
 	}
-	return &Lookup{providerFactory: factory, canBatch: canBatch}
+	return &Lookup{providerFactory: factory, canBatch: canBatch, normalizeProvider: defaultProviderNormalizer}
 }
 
 // Fetch resolves Secret material for leases using the default lookup Module.
@@ -90,7 +94,7 @@ func Fetch(leases []lease.Lease, opts Options) (Secrets, []Error, error) {
 // deduplicated by Provider, account, and source URI, then fetched once and
 // shared by matching Leases.
 func (lookup *Lookup) Fetch(leases []lease.Lease, opts Options) (Secrets, []Error, error) {
-	plan := buildPlan(leases, lookup.canBatch)
+	plan := buildPlan(leases, lookup.canBatch, lookup.normalizeProvider)
 
 	slog.Debug("secret lookup: start",
 		"mode", opts.Mode,
@@ -217,6 +221,14 @@ func defaultBatchPolicy(providerName, sourceURI string) bool {
 	return provider.DefaultRegistry().CanBatch(providerName, sourceURI)
 }
 
+func defaultProviderNormalizer(providerName string) string {
+	canonical, err := provider.DefaultRegistry().CanonicalName(providerName)
+	if err != nil {
+		return provider.NormalizeName(providerName)
+	}
+	return canonical
+}
+
 type plan struct {
 	batches    []batch
 	singletons []sourceGroup
@@ -248,20 +260,21 @@ type sourceKey struct {
 
 type key sourceKey
 
-func buildPlan(leases []lease.Lease, canBatch BatchPolicy) plan {
+func buildPlan(leases []lease.Lease, canBatch BatchPolicy, normalizeProvider ProviderNormalizer) plan {
 	batchesByAccount := make(map[providerAccount]int)
 	singletonsBySource := make(map[sourceKey]int)
 	plan := plan{}
 
 	for _, l := range leases {
-		if canBatch(l.Provider, l.Source) {
-			accountKey := providerAccount{providerName: l.Provider, account: l.OpAccount}
+		providerName := normalizeProvider(l.Provider)
+		if canBatch(providerName, l.Source) {
+			accountKey := providerAccount{providerName: providerName, account: l.OpAccount}
 			idx, ok := batchesByAccount[accountKey]
 			if !ok {
 				idx = len(plan.batches)
 				batchesByAccount[accountKey] = idx
 				plan.batches = append(plan.batches, batch{
-					providerName: l.Provider,
+					providerName: providerName,
 					account:      l.OpAccount,
 				})
 			}
@@ -269,13 +282,13 @@ func buildPlan(leases []lease.Lease, canBatch BatchPolicy) plan {
 			continue
 		}
 
-		singletonKey := sourceKey{providerName: l.Provider, account: l.OpAccount, source: l.Source}
+		singletonKey := sourceKey{providerName: providerName, account: l.OpAccount, source: l.Source}
 		idx, ok := singletonsBySource[singletonKey]
 		if !ok {
 			idx = len(plan.singletons)
 			singletonsBySource[singletonKey] = idx
 			plan.singletons = append(plan.singletons, sourceGroup{
-				providerName: l.Provider,
+				providerName: providerName,
 				account:      l.OpAccount,
 				source:       l.Source,
 			})

--- a/internal/secretlookup/lookup_test.go
+++ b/internal/secretlookup/lookup_test.go
@@ -145,6 +145,37 @@ func TestLookupFetch_GroupsByProviderAccountAndDedupeSource(t *testing.T) {
 	}
 }
 
+func TestLookupFetch_CanonicalizesProviderAliasesBeforeGrouping(t *testing.T) {
+	factory := newRecordingFactory()
+	lookup := NewWithProviderFactory(factory.factory)
+
+	opAlias := lease.Lease{Provider: "op", Source: "op://vault/shared", OpAccount: "account-a", Variable: "OP_ALIAS"}
+	nameAlias := lease.Lease{Provider: "onepassword", Source: "op://vault/shared", OpAccount: "account-a", Variable: "NAME_ALIAS"}
+	caseAlias := lease.Lease{Provider: "1PASSWORD", Source: "op://vault/other", OpAccount: "account-a", Variable: "CASE_ALIAS"}
+
+	_, errs, err := lookup.Fetch([]lease.Lease{opAlias, nameAlias, caseAlias}, Options{})
+	if err != nil {
+		t.Fatalf("unexpected fetch error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected per-lease errors: %v", errs)
+	}
+
+	canonicalProvider := factory.provider("1password", "account-a")
+	if canonicalProvider == nil {
+		t.Fatal("missing canonical 1password provider")
+	}
+	if got := len(canonicalProvider.fetchLeasesCalls); got != 1 {
+		t.Fatalf("bulk calls = %d, want 1", got)
+	}
+	if got := len(canonicalProvider.fetchLeasesCalls[0]); got != 3 {
+		t.Fatalf("bulk lease count = %d, want 3", got)
+	}
+	if factory.provider("op", "account-a") != nil || factory.provider("onepassword", "account-a") != nil || factory.provider("1PASSWORD", "account-a") != nil {
+		t.Fatal("expected aliases to share only the canonical provider adapter")
+	}
+}
+
 func TestLookupFetch_UsesProviderBatchPolicyForNonOnePasswordSchemes(t *testing.T) {
 	factory := newRecordingFactory()
 	lookup := NewWithProviderFactoryAndBatchPolicy(factory.factory, func(providerName, sourceURI string) bool {

--- a/internal/secretlookup/lookup_test.go
+++ b/internal/secretlookup/lookup_test.go
@@ -2,6 +2,7 @@ package secretlookup
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -141,6 +142,60 @@ func TestLookupFetch_GroupsByProviderAccountAndDedupeSource(t *testing.T) {
 	}
 	if got := len(accountBProvider.fetchCalls); got != 0 {
 		t.Fatalf("account-b singleton fetch calls = %d, want 0", got)
+	}
+}
+
+func TestLookupFetch_UsesProviderBatchPolicyForNonOnePasswordSchemes(t *testing.T) {
+	factory := newRecordingFactory()
+	lookup := NewWithProviderFactoryAndBatchPolicy(factory.factory, func(providerName, sourceURI string) bool {
+		return providerName == "vault" && strings.HasPrefix(sourceURI, "vault://")
+	})
+
+	first := lease.Lease{Provider: "vault", Source: "vault://secret/data/app#api_key", Variable: "API_KEY"}
+	second := lease.Lease{Provider: "vault", Source: "vault://secret/data/app#db_url", Variable: "DB_URL"}
+	file := lease.Lease{Provider: "vault", Source: "file://local.json", Variable: "LOCAL"}
+
+	secrets, errs, err := lookup.Fetch([]lease.Lease{first, second, file}, Options{})
+	if err != nil {
+		t.Fatalf("unexpected fetch error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected per-lease errors: %v", errs)
+	}
+
+	vaultProvider := factory.provider("vault", "")
+	if vaultProvider == nil {
+		t.Fatal("missing vault provider")
+	}
+	if got := len(vaultProvider.fetchLeasesCalls); got != 1 {
+		t.Fatalf("bulk calls = %d, want 1", got)
+	}
+	if got := len(vaultProvider.fetchLeasesCalls[0]); got != 2 {
+		t.Fatalf("bulk lease count = %d, want 2", got)
+	}
+	if got := len(vaultProvider.fetchCalls); got != 1 {
+		t.Fatalf("singleton fetch calls = %d, want 1", got)
+	}
+	if got, ok := secrets.Get(file); !ok || got != "secret:vault::file://local.json" {
+		t.Fatalf("singleton secret = %q, %v", got, ok)
+	}
+}
+
+func TestLookupFetch_UnknownProviderReturnsLeaseError(t *testing.T) {
+	missing := lease.Lease{Provider: "vault", Source: "vault://secret/data/app#api_key", Variable: "API_KEY"}
+
+	_, errs, err := New().Fetch([]lease.Lease{missing}, Options{})
+	if err == nil {
+		t.Fatal("expected top-level error")
+	}
+	if len(errs) != 1 {
+		t.Fatalf("per-lease errors = %d, want 1", len(errs))
+	}
+	if errs[0].Lease.Provider != missing.Provider || errs[0].Lease.Source != missing.Source || errs[0].Lease.Variable != missing.Variable {
+		t.Fatalf("error lease = %#v, want %#v", errs[0].Lease, missing)
+	}
+	if !strings.Contains(errs[0].Err.Error(), `unknown provider "vault"`) {
+		t.Fatalf("per-lease error = %q, want unknown provider", errs[0].Err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add a provider registry that localizes adapter selection, provider-name normalization, aliases, and batchable URI schemes.
- Teach secret lookup planning to use provider-owned batch policy instead of hard-coded `op://` checks.
- Document the Provider Adapter seam and add tests for provider selection, unknown providers, and scheme-specific batching.

## Testing

- `gofmt -w cmd internal`
- `mise run lint`
- `mise run test`
- `git diff --check`

## Task

Architecture improvement #4: deepen the Provider expansion seam.
