### PR TITLE
refactor: deepen ipc contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,10 @@ _Avoid_: worker, server, scheduler
 The state transitions that register, expire, retry, reconcile, and revoke active Leases inside the Daemon.
 _Avoid_: state handling, timer logic, daemon cleanup
 
+**IPC Contract**:
+The signed, typed command and response seam between CLI adapters and the Daemon.
+_Avoid_: socket handling, client calls, JSON plumbing
+
 **Config**:
 The TOML declaration that describes desired Leases for a project.
 _Avoid_: manifest, spec, settings
@@ -66,6 +70,7 @@ _Avoid_: manifest, spec, settings
 - The **Grant Workflow** uses **Secret Lookup** before **Secret Transformation**.
 - **Secret Transformation** produces one **Secret** or an exploded set of Secrets for the **Grant Workflow** to materialize at their **Destination**.
 - The **Grant Workflow** produces the request that registers **Leases** with the **Daemon**.
+- The **Grant Workflow** and CLI adapters cross the **IPC Contract** to ask the **Daemon** to register, report, clean up, or revoke **Leases**.
 - The **Daemon** owns the **Lease Lifecycle** for active **Leases**.
 - The **Lease Lifecycle** performs **Revoke** when a **Lease** expires or is removed from **Config**.
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -24,8 +24,7 @@ func ensureDaemonClient() *ipc.Client {
 		return nil
 	}
 
-	var resp ipc.StatusResponse
-	if err := client.Send(ipc.StatusRequest{Command: "status"}, &resp); err != nil {
+	if err := client.CheckDaemon(); err != nil {
 		handleClientError(err)
 	}
 	return client

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -132,7 +132,7 @@ var cleanupCmd = &cobra.Command{
 			return nil
 		}
 
-		req := ipc.CleanupRequest{Command: "cleanup"}
+		req := ipc.CleanupRequest{}
 		var resp ipc.CleanupResponse
 
 		if err := client.Send(req, &resp); err != nil {

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -11,11 +10,6 @@ import (
 
 func handleClientError(err error) {
 	slog.Error("an ipc error occurred", "err", err)
-	var connErr *ipc.ConnectionError
-	if errors.As(err, &connErr) {
-		_, _ = fmt.Fprintln(os.Stderr, "Error: env-lease daemon is not running. Please start it with 'env-lease daemon start'.")
-	} else {
-		_, _ = fmt.Fprintln(os.Stderr, "Error: could not connect to the env-lease daemon. Is it running?")
-	}
+	_, _ = fmt.Fprintln(os.Stderr, ipc.UserMessage(err))
 	os.Exit(1)
 }

--- a/cmd/revoke.go
+++ b/cmd/revoke.go
@@ -34,7 +34,7 @@ var revokeCmd = &cobra.Command{
 			return nil
 		}
 		if interactive {
-			statusReq := ipc.StatusRequest{Command: "status"}
+			statusReq := ipc.StatusRequest{}
 			if !all {
 				statusReq.ConfigFile = absConfigFile
 			}
@@ -111,7 +111,6 @@ var revokeCmd = &cobra.Command{
 			}
 
 			req := ipc.RevokeRequest{
-				Command:    "revoke",
 				ConfigFile: absConfigFile,
 				Leases:     leasesToRevoke,
 			}
@@ -127,7 +126,6 @@ var revokeCmd = &cobra.Command{
 		}
 
 		req := ipc.RevokeRequest{
-			Command:    "revoke",
 			ConfigFile: absConfigFile,
 			All:        all,
 		}
@@ -155,7 +153,7 @@ var revokeCmd = &cobra.Command{
 
 		// If all leases were revoked, check for .envrc and handle direnv
 		var leasesResp ipc.StatusResponse
-		statusReq := ipc.StatusRequest{Command: "status"}
+		statusReq := ipc.StatusRequest{}
 		if err := client.Send(statusReq, &leasesResp); err != nil {
 			// If we can't get the status, we can't check for .envrc, so we'll just print the message and return.
 			handleClientError(err)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -25,7 +25,7 @@ var statusCmd = &cobra.Command{
 			return nil
 		}
 
-		req := ipc.StatusRequest{Command: "status"}
+		req := ipc.StatusRequest{}
 		var resp ipc.StatusResponse
 		if err := client.Send(req, &resp); err != nil {
 			handleClientError(err)

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -9,32 +9,30 @@ import (
 )
 
 func (d *Daemon) handleIPC(payload []byte) ([]byte, error) {
-	var req struct {
-		Command string
-	}
-	if err := json.Unmarshal(payload, &req); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal command: %w", err)
+	command, err := ipc.DecodeCommand(payload)
+	if err != nil {
+		return nil, err
 	}
 
-	switch req.Command {
-	case "grant":
+	switch command {
+	case ipc.CommandGrant:
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		return d.handleGrant(payload)
-	case "revoke":
+	case ipc.CommandRevoke:
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		return d.handleRevoke(payload)
-	case "status":
+	case ipc.CommandStatus:
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		return d.handleStatus(payload)
-	case "cleanup":
+	case ipc.CommandCleanup:
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		return d.handleCleanup(payload)
 	default:
-		return nil, fmt.Errorf("unknown command: %s", req.Command)
+		return nil, fmt.Errorf("unknown command: %s", command)
 	}
 }
 

--- a/internal/grantflow/flow.go
+++ b/internal/grantflow/flow.go
@@ -83,7 +83,6 @@ func (f Flow) Run(set *lease.Set, opts Options) (Result, error) {
 	}
 
 	result.Request = ipc.GrantRequest{
-		Command:    "grant",
 		Leases:     result.Request.Leases,
 		Override:   opts.Override,
 		Append:     opts.Append,

--- a/internal/ipc/client.go
+++ b/internal/ipc/client.go
@@ -22,6 +22,12 @@ func NewClient(socketPath string, secret []byte) *Client {
 	}
 }
 
+// CheckDaemon verifies that the daemon is reachable and can answer status.
+func (c *Client) CheckDaemon() error {
+	var resp StatusResponse
+	return c.Send(StatusRequest{}, &resp)
+}
+
 // Send sends a request to the server and decodes the response.
 func (c *Client) Send(payload any, responsePayload any) error {
 	req, err := NewRequest(payload, c.secret)
@@ -39,26 +45,29 @@ func (c *Client) Send(payload any, responsePayload any) error {
 		return err
 	}
 
-	// Always read the response to properly close the connection and check for errors
 	var resp Response
 	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
-		// If the server sends no body, it's a successful fire-and-forget.
-		// We can treat EOF as a success signal in this specific case.
 		if errors.Is(err, io.EOF) {
-			return nil
+			if responsePayload == nil {
+				return nil
+			}
+			return ErrNoResponse
 		}
 		return fmt.Errorf("failed to decode response: %w", err)
 	}
 
 	if resp.Error != "" {
-		return fmt.Errorf("server error: %s", resp.Error)
+		return &ServerError{Message: resp.Error}
 	}
 
-	// Only unmarshal a payload if the caller is expecting one
-	if responsePayload != nil {
-		if err := json.Unmarshal(resp.Payload, responsePayload); err != nil {
-			return fmt.Errorf("failed to unmarshal response payload: %w", err)
-		}
+	if responsePayload == nil {
+		return nil
+	}
+	if len(resp.Payload) == 0 {
+		return ErrEmptyPayload
+	}
+	if err := json.Unmarshal(resp.Payload, responsePayload); err != nil {
+		return fmt.Errorf("failed to unmarshal response payload: %w", err)
 	}
 
 	return nil

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -5,14 +5,34 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 )
 
-// Request represents a request sent from the CLI to the daemon.
+// Command identifies the daemon operation carried by an IPC request payload.
+type Command string
+
+const (
+	// CommandGrant registers granted Leases with the Daemon.
+	CommandGrant Command = "grant"
+	// CommandStatus asks the Daemon for active Lease state.
+	CommandStatus Command = "status"
+	// CommandCleanup asks the Daemon to reconcile orphaned Leases.
+	CommandCleanup Command = "cleanup"
+	// CommandRevoke asks the Daemon to revoke active Leases.
+	CommandRevoke Command = "revoke"
+)
+
+// Request represents a signed request sent from the CLI to the daemon.
 type Request struct {
 	Signature string
 	Payload   []byte
+}
+
+// CommandCarrier is implemented by typed daemon request payloads.
+type CommandCarrier interface {
+	IPCCommand() Command
 }
 
 // GrantRequest is the payload for a grant request.
@@ -23,6 +43,9 @@ type GrantRequest struct {
 	Append     bool
 	ConfigFile string
 }
+
+// IPCCommand returns the daemon command represented by GrantRequest.
+func (GrantRequest) IPCCommand() Command { return CommandGrant }
 
 // GrantResponse is the payload for a grant response.
 type GrantResponse struct {
@@ -35,15 +58,23 @@ type StatusRequest struct {
 	ConfigFile string
 }
 
+// IPCCommand returns the daemon command represented by StatusRequest.
+func (StatusRequest) IPCCommand() Command { return CommandStatus }
+
 // StatusResponse is the payload for a status response.
 type StatusResponse struct {
 	Leases []Lease
 }
 
+// CleanupRequest is the payload for a cleanup request.
 type CleanupRequest struct {
 	Command string
 }
 
+// IPCCommand returns the daemon command represented by CleanupRequest.
+func (CleanupRequest) IPCCommand() Command { return CommandCleanup }
+
+// CleanupResponse is the payload for a cleanup response.
 type CleanupResponse struct {
 	Messages []string
 }
@@ -55,6 +86,9 @@ type RevokeRequest struct {
 	All        bool
 	Leases     []Lease
 }
+
+// IPCCommand returns the daemon command represented by RevokeRequest.
+func (RevokeRequest) IPCCommand() Command { return CommandRevoke }
 
 // RevokeResponse is the payload for a revoke response.
 type RevokeResponse struct {
@@ -89,7 +123,7 @@ func Sign(payload []byte, secret []byte) string {
 func Verify(payload []byte, signature string, secret []byte) error {
 	expectedSignature := Sign(payload, secret)
 	if !hmac.Equal([]byte(signature), []byte(expectedSignature)) {
-		return fmt.Errorf("invalid signature")
+		return ErrInvalidSignature
 	}
 	return nil
 }
@@ -99,6 +133,15 @@ type Response struct {
 	Error   string          `json:"error,omitempty"`
 	Payload json.RawMessage `json:"payload,omitempty"`
 }
+
+var (
+	// ErrInvalidSignature means the request signature did not match the payload.
+	ErrInvalidSignature = errors.New("invalid signature")
+	// ErrNoResponse means the daemon closed the connection before sending a response.
+	ErrNoResponse = errors.New("daemon closed connection without a response")
+	// ErrEmptyPayload means the daemon returned success without a payload for a typed response.
+	ErrEmptyPayload = errors.New("daemon returned no response payload")
+)
 
 // ConnectionError is a custom error for IPC connection errors.
 type ConnectionError struct {
@@ -114,9 +157,27 @@ func (e *ConnectionError) Unwrap() error {
 	return e.Err
 }
 
+// ServerError wraps an error response returned by the daemon.
+type ServerError struct {
+	Message string
+}
+
+func (e *ServerError) Error() string {
+	return fmt.Sprintf("server error: %s", e.Message)
+}
+
+// UserMessage maps low-level IPC failures to stable CLI-facing text.
+func UserMessage(err error) string {
+	var connErr *ConnectionError
+	if errors.As(err, &connErr) {
+		return "Error: env-lease daemon is not running. Please start it with 'env-lease daemon start'."
+	}
+	return "Error: could not connect to the env-lease daemon. Is it running?"
+}
+
 // NewRequest creates a new signed request.
 func NewRequest(payload any, secret []byte) (*Request, error) {
-	payloadBytes, err := json.Marshal(payload)
+	payloadBytes, err := json.Marshal(normalizeCommand(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -126,4 +187,65 @@ func NewRequest(payload any, secret []byte) (*Request, error) {
 		Signature: signature,
 		Payload:   payloadBytes,
 	}, nil
+}
+
+func normalizeCommand(payload any) any {
+	switch req := payload.(type) {
+	case GrantRequest:
+		if req.Command == "" {
+			req.Command = string(req.IPCCommand())
+		}
+		return req
+	case *GrantRequest:
+		if req != nil && req.Command == "" {
+			copy := *req
+			copy.Command = string(req.IPCCommand())
+			return copy
+		}
+	case StatusRequest:
+		if req.Command == "" {
+			req.Command = string(req.IPCCommand())
+		}
+		return req
+	case *StatusRequest:
+		if req != nil && req.Command == "" {
+			copy := *req
+			copy.Command = string(req.IPCCommand())
+			return copy
+		}
+	case CleanupRequest:
+		if req.Command == "" {
+			req.Command = string(req.IPCCommand())
+		}
+		return req
+	case *CleanupRequest:
+		if req != nil && req.Command == "" {
+			copy := *req
+			copy.Command = string(req.IPCCommand())
+			return copy
+		}
+	case RevokeRequest:
+		if req.Command == "" {
+			req.Command = string(req.IPCCommand())
+		}
+		return req
+	case *RevokeRequest:
+		if req != nil && req.Command == "" {
+			copy := *req
+			copy.Command = string(req.IPCCommand())
+			return copy
+		}
+	}
+	return payload
+}
+
+// DecodeCommand extracts the command from a signed request payload.
+func DecodeCommand(payload []byte) (Command, error) {
+	var req struct {
+		Command string
+	}
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return "", fmt.Errorf("failed to unmarshal command: %w", err)
+	}
+	return Command(req.Command), nil
 }

--- a/internal/ipc/ipc_test.go
+++ b/internal/ipc/ipc_test.go
@@ -1,70 +1,158 @@
 package ipc
 
 import (
-	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
-func TestIPC(t *testing.T) {
-	socketPath := filepath.Join(t.TempDir(), "test.sock")
-	secret := make([]byte, 32)
-	if _, err := rand.Read(secret); err != nil {
-		t.Fatalf("failed to generate secret: %v", err)
+func TestClientServerTypedRequestResponse(t *testing.T) {
+	server, client := newTestIPC(t, []byte("shared-secret"))
+	commandCh := make(chan Command, 1)
+
+	go func() {
+		_ = server.Listen(func(payload []byte) ([]byte, error) {
+			command, err := DecodeCommand(payload)
+			if err != nil {
+				return nil, err
+			}
+			commandCh <- command
+			return json.Marshal(GrantResponse{Messages: []string{"granted"}})
+		})
+	}()
+
+	var resp GrantResponse
+	if err := client.Send(GrantRequest{Leases: []Lease{{Source: "test"}}}, &resp); err != nil {
+		t.Fatalf("client send failed: %v", err)
+	}
+	if got, want := resp.Messages, []string{"granted"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("response messages = %v, want %v", got, want)
+	}
+	if got := <-commandCh; got != CommandGrant {
+		t.Fatalf("command = %q, want %q", got, CommandGrant)
+	}
+}
+
+func TestServerRejectsInvalidSignature(t *testing.T) {
+	server, _ := newTestIPC(t, []byte("server-secret"))
+	handled := make(chan struct{}, 1)
+
+	go func() {
+		_ = server.Listen(func(payload []byte) ([]byte, error) {
+			handled <- struct{}{}
+			return nil, nil
+		})
+	}()
+
+	badClient := NewClient(server.SocketPath(), []byte("client-secret"))
+	var resp StatusResponse
+	err := badClient.Send(StatusRequest{}, &resp)
+	var serverErr *ServerError
+	if !errors.As(err, &serverErr) {
+		t.Fatalf("error = %v, want ServerError", err)
+	}
+	if serverErr.Message != ErrInvalidSignature.Error() {
+		t.Fatalf("server error message = %q, want %q", serverErr.Message, ErrInvalidSignature.Error())
+	}
+	select {
+	case <-handled:
+		t.Fatal("handler ran for an invalid signature")
+	default:
+	}
+}
+
+func TestClientReturnsDaemonError(t *testing.T) {
+	server, client := newTestIPC(t, []byte("shared-secret"))
+	go func() {
+		_ = server.Listen(func(payload []byte) ([]byte, error) {
+			return nil, errors.New("boom")
+		})
+	}()
+
+	err := client.Send(StatusRequest{}, &StatusResponse{})
+	var serverErr *ServerError
+	if !errors.As(err, &serverErr) {
+		t.Fatalf("error = %v, want ServerError", err)
+	}
+	if serverErr.Message != "boom" {
+		t.Fatalf("server error message = %q, want boom", serverErr.Message)
+	}
+}
+
+func TestClientEOFBehavior(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "env-lease-ipc-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	socketPath := filepath.Join(tmpDir, "eof.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	client := NewClient(socketPath, []byte("shared-secret"))
+	if err := client.Send(StatusRequest{}, nil); err != nil {
+		t.Fatalf("nil response payload error = %v, want nil", err)
+	}
+	if err := client.Send(StatusRequest{}, &StatusResponse{}); !errors.Is(err, ErrNoResponse) {
+		t.Fatalf("typed response error = %v, want ErrNoResponse", err)
+	}
+}
+
+func TestClientRequiresPayloadForTypedResponse(t *testing.T) {
+	server, client := newTestIPC(t, []byte("shared-secret"))
+	go func() {
+		_ = server.Listen(func(payload []byte) ([]byte, error) {
+			return nil, nil
+		})
+	}()
+
+	if err := client.Send(StatusRequest{}, &StatusResponse{}); !errors.Is(err, ErrEmptyPayload) {
+		t.Fatalf("error = %v, want ErrEmptyPayload", err)
+	}
+}
+
+func TestConnectionErrorUserMessage(t *testing.T) {
+	client := NewClient(filepath.Join(t.TempDir(), "missing.sock"), []byte("shared-secret"))
+	err := client.Send(StatusRequest{}, &StatusResponse{})
+	var connErr *ConnectionError
+	if !errors.As(err, &connErr) {
+		t.Fatalf("error = %v, want ConnectionError", err)
 	}
 
+	want := "Error: env-lease daemon is not running. Please start it with 'env-lease daemon start'."
+	if got := UserMessage(err); got != want {
+		t.Fatalf("UserMessage = %q, want %q", got, want)
+	}
+}
+
+func newTestIPC(t *testing.T, secret []byte) (*Server, *Client) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("/tmp", "env-lease-ipc-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	socketPath := filepath.Join(tmpDir, "test.sock")
 	server, err := NewServer(socketPath, secret)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
-	defer server.Close()
-
-	handlerChan := make(chan []byte, 1)
-	handler := func(payload []byte) ([]byte, error) {
-		handlerChan <- payload
-		return nil, nil
-	}
-	go server.Listen(handler)
-
-	// Allow server to start
-	time.Sleep(100 * time.Millisecond)
-
-	t.Run("successful communication", func(t *testing.T) {
-		client := NewClient(socketPath, secret)
-		payload := GrantRequest{
-			Leases: []Lease{{Source: "test"}},
-		}
-		if err := client.Send(payload, nil); err != nil {
-			t.Fatalf("client send failed: %v", err)
-		}
-
-		select {
-		case receivedPayload := <-handlerChan:
-			// Just check that we got something
-			if len(receivedPayload) == 0 {
-				t.Error("handler received empty payload")
-			}
-		case <-time.After(1 * time.Second):
-			t.Fatal("handler did not receive payload in time")
-		}
-	})
-
-	t.Run("invalid signature", func(t *testing.T) {
-		badSecret := make([]byte, 32)
-		client := NewClient(socketPath, badSecret)
-		payload := GrantRequest{
-			Leases: []Lease{{Source: "test"}},
-		}
-		if err := client.Send(payload, nil); err != nil {
-			t.Fatalf("client send failed: %v", err)
-		}
-
-		select {
-		case <-handlerChan:
-			t.Fatal("handler should not have received payload")
-		case <-time.After(100 * time.Millisecond):
-			// Expected timeout
-		}
-	})
+	t.Cleanup(func() { _ = server.Close() })
+	return server, NewClient(socketPath, secret)
 }

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -54,15 +54,20 @@ func (s *Server) handleConnection(conn net.Conn, handler func(payload []byte) ([
 
 	if err := Verify(req.Payload, req.Signature, s.secret); err != nil {
 		fmt.Fprintf(os.Stderr, "invalid signature: %v\n", err)
+		s.writeResponse(conn, nil, err)
 		return
 	}
 
 	responsePayload, err := handler(req.Payload)
+	s.writeResponse(conn, responsePayload, err)
+}
+
+func (s *Server) writeResponse(conn net.Conn, payload []byte, err error) {
 	resp := &Response{}
 	if err != nil {
 		resp.Error = err.Error()
 	} else {
-		resp.Payload = responsePayload
+		resp.Payload = payload
 	}
 
 	if err := json.NewEncoder(conn).Encode(resp); err != nil {


### PR DESCRIPTION
## Summary
- Deepen `internal/ipc` into the typed IPC Contract seam with command constants, automatic command normalization, daemon preflight, and centralized CLI-facing error mapping.
- Return structured daemon errors for invalid signatures and daemon handler failures while preserving the existing response envelope.
- Add IPC tests for typed request/response handling, invalid signatures, daemon errors, EOF/no-payload behavior, and connection error mapping.
- Document the IPC Contract term in `CONTEXT.md`.

## Testing
- `gofmt -w cmd internal`
- `mise run lint`
- `mise run test`
- `git diff --check`

## Notes
- The response envelope remains compatible. Empty daemon responses are still accepted for fire-and-forget calls; typed response callers now get explicit errors for EOF/no payload.
